### PR TITLE
Add Levina–Bickel MLE intrinsic-dimension demo, estimator utilities, and tests

### DIFF
--- a/assets/js/id-estimator.js
+++ b/assets/js/id-estimator.js
@@ -1,0 +1,41 @@
+/**
+ * Levina–Bickel MLE helpers.
+ * Kept dependency-free so both browser and Node tests can use the same code.
+ */
+
+export function localMleFromSortedDistances(sortedDistances, k) {
+  if (!Array.isArray(sortedDistances) || sortedDistances.length < 2) return NaN;
+  const kEff = Math.max(2, Math.min(k, sortedDistances.length));
+  const Tk = sortedDistances[kEff - 1];
+  if (!(Tk > 0)) return NaN;
+
+  let sum = 0;
+  for (let j = 0; j < kEff - 1; j += 1) {
+    const Tj = sortedDistances[j];
+    if (!(Tj > 0) || Tj > Tk) return NaN;
+    sum += Math.log(Tk / Tj);
+  }
+  const avg = sum / (kEff - 1);
+  return avg > 0 ? 1 / avg : NaN;
+}
+
+export function pairwiseSortedDistances(points) {
+  return points.map((p, i) => {
+    const ds = [];
+    for (let j = 0; j < points.length; j += 1) {
+      if (i === j) continue;
+      const q = points[j];
+      ds.push(Math.hypot(p.x - q.x, p.y - q.y));
+    }
+    ds.sort((a, b) => a - b);
+    return ds;
+  });
+}
+
+export function datasetMle(points, k) {
+  const cache = pairwiseSortedDistances(points);
+  const vals = cache.map((d) => localMleFromSortedDistances(d, k)).filter(Number.isFinite);
+  if (!vals.length) return NaN;
+  return vals.reduce((a, b) => a + b, 0) / vals.length;
+}
+

--- a/projects/index.html
+++ b/projects/index.html
@@ -42,7 +42,7 @@
 <div class="post-content">
 <p>A few things I'm working on:</p>
 <ul>
-<li><strong>Intrinsic Dimensionality</strong> – Studying compact latent structures in language representations and how they evolve across layers.</li>
+<li><strong><a href="/projects/intrinsic-dimensionality/">Intrinsic Dimensionality (Levina–Bickel MLE demo)</a></strong> – Interactive explainer for local neighbor-based intrinsic dimension estimation.</li>
 </ul>
 <p>
 <img src="/random/tea/img/tea.jpeg" alt="Cute teacup photo for the Intrinsic Dimensionality project" style="max-width:320px;width:100%;border-radius:14px;display:block;margin-top:12px;">

--- a/projects/intrinsic-dimensionality/index.html
+++ b/projects/intrinsic-dimensionality/index.html
@@ -5,8 +5,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
   <meta name="robots" content="index, follow">
-  <title>Intrinsic Dimensionality methods | lucia's notes</title>
-  <meta name="description" content="Cinematic interactive explainer for intrinsic dimensionality (Levina–Bickel MLE).">
+  <title>Levina–Bickel MLE Intrinsic Dimensionality | lucia's notes</title>
+  <meta name="description" content="Interactive explainer for Levina–Bickel MLE intrinsic dimensionality with local and aggregate k-NN views.">
   <meta name="author" content="Lucia">
   <link rel="canonical" href="https://ldomenichelli.github.io/projects/intrinsic-dimensionality/">
   <link crossorigin="anonymous" href="/assets/css/stylesheet.5ad9b1caa92e4cea83ebcd3088e97362f239b07d8144490aaf0bc1d6bd89cd17.css" integrity="sha256-WtmxyqkuTOqD680wiOlzYvI5sH2BREkKrwvB1r2JzRc=" rel="preload stylesheet" as="style">
@@ -15,71 +15,311 @@
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js" integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4" crossorigin="anonymous"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js" integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa" crossorigin="anonymous" onload='renderMathInElement(document.body,{delimiters:[{left:"$$",right:"$$",display:true},{left:"$",right:"$",display:false}]})'></script>
   <style>
-    :root{--bg:#000000;--panel:#0B0D12;--panel-2:#121723;--text:#EAF2FF;--muted:#B5C5E0;--cyan:#3EDCFF;--violet:#8E7BFF;--amber:#FFB84D;--border:#273045;--focus:#62E6FF}
-    body#top.dark{background:var(--bg);color:var(--text)} .main{max-width:1220px} .post-content{max-width:74ch;line-height:1.75}
-    .cinematic-wrap{position:relative;overflow:hidden}
-    .ambient-glow{position:absolute;inset:-220px auto auto -140px;width:520px;height:520px;border-radius:50%;background:radial-gradient(circle,rgba(62,220,255,.18),rgba(62,220,255,0));pointer-events:none;filter:blur(2px)}
-    .ambient-glow.violet{inset:140px -170px auto auto;background:radial-gradient(circle,rgba(142,123,255,.16),rgba(142,123,255,0))}
-    .hero-card,.panel{position:relative;background:linear-gradient(165deg,var(--panel),var(--panel-2));border:1px solid var(--border);border-radius:16px}
-    .hero-card{padding:18px;margin:14px 0 18px;overflow:hidden}
-    .hero-grid{display:grid;grid-template-columns:1.15fr .85fr;gap:16px;align-items:center}
-    .hero-title{font-size:clamp(1.25rem,3.2vw,2rem);margin:.2rem 0 .7rem}
-    .badge{display:inline-block;border:1px solid #3d4a6b;color:var(--cyan);padding:3px 10px;border-radius:999px;font-size:.8rem;letter-spacing:.02em}
-    .layout{display:grid;grid-template-columns:1.35fr .85fr;gap:16px;align-items:start}
-    .panel{padding:16px} .panel h3{margin:.2rem 0 .6rem;font-size:1.1rem} .subtle{color:var(--muted);font-size:.94rem} .result{font-weight:700}
-    .controls{display:grid;gap:10px;margin-top:10px} .controls-grid{display:grid;gap:12px;grid-template-columns:repeat(2,minmax(0,1fr))}
-    label{font-size:.92rem;color:var(--text)} input[type="range"],select{width:100%} select,input[type="range"]{accent-color:var(--cyan)}
-    select{background:#0D1320;color:var(--text);border:1px solid #3A4A73;border-radius:10px;padding:8px}
-    .btn{background:linear-gradient(180deg,#11293a,#0b1b2a);color:var(--text);border:1px solid #2e5972;border-radius:10px;padding:.6rem .9rem;cursor:pointer;font-weight:600;transition:transform .18s ease, box-shadow .18s ease, border-color .18s ease}
-    .btn:hover{transform:translateY(-1px);border-color:var(--cyan);box-shadow:0 0 0 2px rgba(62,220,255,.22)}
-    .btn:focus-visible,select:focus-visible,input:focus-visible,canvas:focus-visible{outline:2px solid var(--focus);outline-offset:2px;box-shadow:0 0 0 3px rgba(98,230,255,.28)}
-    canvas{width:100%;height:auto;border:1.5px solid #3B4B76;border-radius:12px;background:#050812}
-    .formula-sticky{position:sticky;top:90px} .formula-eq{padding:10px;border:1px solid #394766;border-radius:10px;background:rgba(9,16,28,.75);overflow:auto}
-    .passages li{margin:.5rem 0} .warning{color:var(--amber);font-weight:600}
-    table{width:100%;border-collapse:collapse;margin-top:8px} th,td{border-bottom:1px solid #2c3752;padding:6px 4px;text-align:left;font-size:.92rem}
-    .legend{display:flex;flex-wrap:wrap;gap:8px;margin-top:8px} .legend span{font-size:.84rem;border:1px solid #334568;border-radius:999px;padding:2px 9px}
-    @media (prefers-reduced-motion: reduce){*{animation:none !important;transition:none !important;scroll-behavior:auto !important}}
-    @media (max-width:980px){.hero-grid,.layout{grid-template-columns:1fr}.formula-sticky{position:static}.controls-grid{grid-template-columns:1fr}}
+    :root { --bg:#090c14; --panel:#111827; --panel-2:#182236; --text:#e9f1ff; --muted:#b4c3df; --cyan:#58d6ff; --violet:#9b8cff; --border:#334667; --focus:#7de6ff; --amber:#ffbf66; }
+    body#top.dark { background:var(--bg); color:var(--text); }
+    .main { max-width:1220px; } .post-content { max-width:98ch; line-height:1.68; }
+    .hero,.panel{background:linear-gradient(165deg,var(--panel),var(--panel-2));border:1px solid var(--border);border-radius:16px}
+    .hero{padding:20px;margin:16px 0 18px}.hero h1{margin:0 0 10px;font-size:clamp(1.35rem,3.2vw,2rem)}
+    .badge{display:inline-block;border:1px solid #3f5a80;color:var(--cyan);border-radius:999px;padding:4px 10px;font-size:.82rem;margin-bottom:8px}
+    .layout{display:grid;grid-template-columns:1.2fr .8fr;gap:16px;align-items:start}
+    .panel{padding:16px}.panel h2{margin-top:.1rem;font-size:1.1rem}.subtle{color:var(--muted)}
+    .formula{border:1px solid #3a4d74;background:rgba(12,20,33,.75);border-radius:12px;padding:10px;overflow:auto}
+
+    .controls{display:grid;gap:10px;grid-template-columns:repeat(3,minmax(0,1fr));margin-bottom:12px}
+    .control{display:grid;gap:4px}.control label{font-size:.9rem}
+    input[type="range"],select,button{width:100%;accent-color:var(--cyan)}
+    select,button{background:#0f1523;color:var(--text);border:1px solid #3b4b6e;border-radius:8px;padding:8px}
+    button{cursor:pointer;font-weight:600}
+    button:hover{border-color:var(--cyan)}
+
+    .demo-layout{display:grid;grid-template-columns:1.05fr .95fr;gap:12px}
+    canvas{width:100%;height:auto;border:1px solid #3b4b6e;border-radius:12px;background:#080d18}
+    .metrics{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px}
+    .metric{border:1px solid #324568;background:rgba(9,15,27,.7);border-radius:10px;padding:8px}
+    .metric .k{display:block;font-size:.77rem;color:var(--muted)} .metric .v{font-size:1rem;font-weight:700}
+    .terms{max-height:220px;overflow:auto;border:1px solid #2f4368;border-radius:10px}
+    table{width:100%;border-collapse:collapse;font-size:.86rem} th,td{padding:6px;border-bottom:1px solid #2b3d61;text-align:left}
+
+    .aggregate-layout{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:12px}
+    .hist-wrap{border:1px solid #2f4368;border-radius:10px;padding:8px;background:rgba(8,14,25,.7)}
+    .warning{color:var(--amber);font-size:.88rem}
+
+    a:focus-visible,button:focus-visible,input:focus-visible,select:focus-visible,canvas:focus-visible{outline:2px solid var(--focus);outline-offset:2px;box-shadow:0 0 0 3px rgba(125,230,255,.28)}
+    @media (max-width:1024px){.controls{grid-template-columns:repeat(2,minmax(0,1fr))}.layout,.demo-layout,.aggregate-layout{grid-template-columns:1fr}.metrics{grid-template-columns:repeat(2,minmax(0,1fr))}}
+    @media (max-width:640px){.controls,.metrics{grid-template-columns:1fr}}
   </style>
 <script src="/assets/js/analytics.js" async></script></head>
 <body class="dark" id="top">
-<header class="header"><nav class="nav"><div class="logo"><a href="https://ldomenichelli.github.io/" accesskey="h" title="lucia's notes (Alt + H)">lucia's notes</a><div class="logo-switches"><ul class="lang-switch"><li>|</li></ul></div></div><button id="menu-trigger" aria-haspopup="menu" aria-label="Menu Button"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentcolor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-menu"><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="18" x2="21" y2="18"/></svg></button><ul class="menu hidden"><li><a href="https://ldomenichelli.github.io/about/" title="about"><span>about</span></a></li><li><a href="https://ldomenichelli.github.io/posts/" title="notes"><span>notes</span></a></li><li><a href="https://ldomenichelli.github.io/projects/" title="projects"><span class="active">projects</span></a></li><li><a href="https://ldomenichelli.github.io/random/" title="hobbies"><span>hobbies</span></a></li></ul></nav></header>
-<main class="main cinematic-wrap"><div class="ambient-glow"></div><div class="ambient-glow violet"></div>
-<article class="post-single"><header class="post-header"><div class="breadcrumbs"><a href="/projects/">Projects</a></div><h1 class="post-title">Intrinsic Dimensionality methods</h1></header>
-<div class="post-content">
-<section class="hero-card" aria-labelledby="hero-title"><div class="hero-grid"><div><span class="badge">Research demo</span><h2 id="hero-title" class="hero-title">Cinematic explainer of local and aggregate intrinsic dimension</h2><p class="subtle">Observe how nearest-neighbor geometry, noise, and outliers alter the Levina–Bickel estimate. The animation and controls below are tuned for high-contrast, technical readability.</p><div class="legend"><span style="color:var(--cyan)">Cyan: data manifold</span><span style="color:var(--violet)">Violet: highlighted neighbors</span><span style="color:var(--amber)">Amber: selected point</span></div></div><div><canvas id="heroCanvas" width="620" height="280" aria-label="Animated manifold point cloud"></canvas></div></div></section>
-<div class="layout">
-<section class="panel" aria-labelledby="nn-title"><h3 id="nn-title">Nearest-neighbor visualization</h3><p class="subtle">Click a point to inspect local geometry. Controls update the toy manifold generator and highlight failure modes.</p>
-<div class="controls controls-grid"><div><label for="manifoldType">Manifold type</label><select id="manifoldType" aria-label="Manifold type"><option value="line">Line</option><option value="plane" selected>Plane</option></select></div><div><label for="kRange">k neighbors: <strong id="kValue">8</strong></label><input id="kRange" type="range" min="3" max="30" value="8"></div><div><label for="nPoints">Points: <strong id="nPointsValue">160</strong></label><input id="nPoints" type="range" min="50" max="340" value="160"></div><div><label for="noiseSlider">Noise std: <strong id="noiseValue">0.02</strong></label><input id="noiseSlider" type="range" min="0" max="0.12" step="0.005" value="0.02"></div><div><label for="outlierSlider">Outlier fraction: <strong id="outlierValue">0.00</strong></label><input id="outlierSlider" type="range" min="0" max="0.5" step="0.02" value="0"></div><div style="display:flex;align-items:flex-end"><button class="btn" id="regenBtn" aria-label="Regenerate manifold" style="width:100%">Regenerate manifold</button></div></div>
-<p id="status" class="subtle" aria-live="polite"></p>
-<canvas id="simCanvas" width="840" height="460" tabindex="0" aria-label="Point cloud inspector. Click or use arrow keys."></canvas>
-<p class="subtle" style="margin-top:8px">Thicker circles mark neighbor radii $T_1,\dots,T_k$ with strong focus visibility.</p>
-<table><thead><tr><th>j</th><th>$T_j$</th><th>$\log(T_k/T_j)$</th></tr></thead><tbody id="termsBody"></tbody></table></section>
-<aside class="formula-sticky"><section class="panel" aria-labelledby="formula-title"><h3 id="formula-title">Formula + derivation passages</h3><div class="formula-eq">$$\hat m_k(x)=\left[\frac{1}{k-1}\sum_{j=1}^{k-1}\log\frac{T_k(x)}{T_j(x)}\right]^{-1},\quad \hat m=\frac{1}{n}\sum_{i=1}^{n}\hat m_k(x_i)$$</div><ol class="passages subtle"><li>Count neighbors in $S_x(t)$: $$N(t,x)=\sum_i \mathbf{1}\{X_i\in S_x(t)\}$$</li><li>Assume local Poisson intensity: $$\lambda(t)=f(x)V(m)mt^{m-1}$$</li><li>Build log-likelihood and solve for $m$.</li><li>Switch from radius-$R$ form to practical $k$-NN form.</li></ol><p class="warning">Warning: high noise / many outliers can inflate or destabilize estimates.</p></section>
-<section class="panel" aria-labelledby="agg-title"><h3 id="agg-title">Histogram + aggregate estimates</h3><p class="result">Local MLE: <span id="mleValue">—</span></p><p class="result">Dataset average MLE: <span id="globalMleValue">—</span></p><p class="subtle">k-range average <span id="kRangeSummary">k=4..12</span>: <span id="aggRangeValue">—</span></p><canvas id="histCanvas" width="520" height="260" aria-label="Histogram of local MLE estimates"></canvas></section></aside>
-</div>
-<p><a href="/projects/">← Back to Projects</a></p></div></article></main>
-<script>
-const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-const state = { points: [], selectedIndex: 0, manifoldType: 'plane', nPoints: 160, k: 8, noise: 0.02, outlierFrac: 0, t: 0 };
-const el = {manifoldType: document.getElementById('manifoldType'), nPoints: document.getElementById('nPoints'), nPointsValue: document.getElementById('nPointsValue'), kRange: document.getElementById('kRange'), kValue: document.getElementById('kValue'), noise: document.getElementById('noiseSlider'), noiseValue: document.getElementById('noiseValue'), outlier: document.getElementById('outlierSlider'), outlierValue: document.getElementById('outlierValue'), regen: document.getElementById('regenBtn'), status: document.getElementById('status'), mle: document.getElementById('mleValue'), gmle: document.getElementById('globalMleValue'), agg: document.getElementById('aggRangeValue'), kSummary: document.getElementById('kRangeSummary'), termsBody: document.getElementById('termsBody'), simCanvas: document.getElementById('simCanvas'), heroCanvas: document.getElementById('heroCanvas'), histCanvas: document.getElementById('histCanvas')};
-const simCtx = el.simCanvas.getContext('2d'); const heroCtx = el.heroCanvas.getContext('2d'); const histCtx = el.histCanvas.getContext('2d'); let neighborCache=[];
-function randn(){let u=0,v=0;while(!u)u=Math.random();while(!v)v=Math.random();return Math.sqrt(-2*Math.log(u))*Math.cos(2*Math.PI*v)}
-function genPoints(){const pts=[];const nOut=Math.floor(state.nPoints*state.outlierFrac);const nCore=state.nPoints-nOut;if(state.manifoldType==='line'){const a=Math.PI/6;for(let i=0;i<nCore;i++){const t=0.12+0.76*Math.random();const x=0.5+(t-0.5)*Math.cos(a)+state.noise*randn();const y=0.5+(t-0.5)*Math.sin(a)+state.noise*randn();if(x>.02&&x<.98&&y>.02&&y<.98)pts.push({x,y});}}else{for(let i=0;i<nCore;i++){let x=0.08+0.84*Math.random()+state.noise*0.4*randn();let y=0.08+0.84*Math.random()+state.noise*0.4*randn();x=Math.max(.02,Math.min(.98,x));y=Math.max(.02,Math.min(.98,y));pts.push({x,y});}}for(let i=0;i<nOut;i++)pts.push({x:Math.random(),y:Math.random()});return pts;}
-function distancesFrom(i,canvas){const p=state.points[i],w=canvas.width,h=canvas.height;return state.points.map((q,j)=>({j,d:Math.hypot((q.x-p.x)*w,(q.y-p.y)*h)})).filter(o=>o.j!==i).sort((a,b)=>a.d-b.d)}
-function localMle(sorted,k){if(k<3||sorted.length<k)return NaN;const Tk=sorted[k-1];let s=0;for(let j=0;j<k-1;j++)s+=Math.log(Tk/sorted[j]);return 1/(s/(k-1));}
-function rebuildCache(){neighborCache=[];for(let i=0;i<state.points.length;i++)neighborCache.push(distancesFrom(i,el.simCanvas).map(o=>o.d));}
-function datasetAvg(k){const vals=[];for(const d of neighborCache){const m=localMle(d,k);if(Number.isFinite(m))vals.push(m);}return vals.length?vals.reduce((a,b)=>a+b,0)/vals.length:NaN}
-function kRangeAverage(){const k1=Math.max(3,state.k-4),k2=Math.min(30,state.k+4,neighborCache[0]?.length||state.k);let sum=0,c=0;for(let k=k1;k<=k2;k++){const m=datasetAvg(k);if(Number.isFinite(m)){sum+=m;c++;}}el.kSummary.textContent=`k=${k1}..${k2}`;return c?sum/c:NaN;}
-function drawMain(){const w=el.simCanvas.width,h=el.simCanvas.height;simCtx.clearRect(0,0,w,h);const g=simCtx.createLinearGradient(0,0,w,h);g.addColorStop(0,'#070D19');g.addColorStop(1,'#050812');simCtx.fillStyle=g;simCtx.fillRect(0,0,w,h);const i=state.selectedIndex,p=state.points[i];if(!p)return;const sorted=distancesFrom(i,el.simCanvas),k=Math.min(state.k,sorted.length),ax=p.x*w,ay=p.y*h;simCtx.fillStyle='rgba(62,220,255,0.95)';for(const q of state.points){simCtx.beginPath();simCtx.arc(q.x*w,q.y*h,3.1,0,Math.PI*2);simCtx.fill();}for(let j=0;j<k;j++){const r=sorted[j].d;simCtx.strokeStyle=j===k-1?'rgba(255,184,77,.88)':'rgba(142,123,255,.68)';simCtx.lineWidth=j===k-1?3.2:2.2;simCtx.beginPath();simCtx.arc(ax,ay,r,0,Math.PI*2);simCtx.stroke();}for(let j=0;j<k;j++){const q=state.points[sorted[j].j];simCtx.fillStyle='rgba(142,123,255,0.98)';simCtx.beginPath();simCtx.arc(q.x*w,q.y*h,4.4,0,Math.PI*2);simCtx.fill();}simCtx.fillStyle='rgba(255,184,77,1)';simCtx.beginPath();simCtx.arc(ax,ay,6.3,0,Math.PI*2);simCtx.fill();}
-function drawHistogram(values){const w=el.histCanvas.width,h=el.histCanvas.height;histCtx.clearRect(0,0,w,h);histCtx.fillStyle='#050812';histCtx.fillRect(0,0,w,h);const clean=values.filter(Number.isFinite);if(!clean.length)return;const min=Math.max(0,Math.min(...clean)),max=Math.max(...clean,min+1e-6),bins=14;const counts=new Array(bins).fill(0);for(const v of clean){const b=Math.min(bins-1,Math.floor((v-min)/(max-min)*bins));counts[b]++;}const maxC=Math.max(...counts,1),bw=(w-40)/bins;histCtx.strokeStyle='rgba(58,75,118,.9)';histCtx.lineWidth=2;histCtx.strokeRect(30,20,w-40,h-40);for(let i=0;i<bins;i++){const bh=(counts[i]/maxC)*(h-56);histCtx.fillStyle='rgba(62,220,255,.75)';histCtx.fillRect(32+i*bw,h-22-bh,bw-3,bh);}}
-function updateMetrics(){const i=Math.min(state.selectedIndex,Math.max(0,state.points.length-1));state.selectedIndex=i;const d=neighborCache[i]||[];const k=Math.min(state.k,d.length);el.kValue.textContent=String(k);el.nPointsValue.textContent=String(state.nPoints);el.noiseValue.textContent=state.noise.toFixed(3);el.outlierValue.textContent=state.outlierFrac.toFixed(2);const local=localMle(d,k),global=datasetAvg(k),agg=kRangeAverage();el.mle.textContent=Number.isFinite(local)?local.toFixed(4):'—';el.gmle.textContent=Number.isFinite(global)?global.toFixed(4):'—';el.agg.textContent=Number.isFinite(agg)?agg.toFixed(4):'—';el.status.textContent=`Selected #${i+1} • ${state.manifoldType} • noise=${state.noise.toFixed(3)} • outliers=${state.outlierFrac.toFixed(2)}`;el.termsBody.innerHTML='';if(k>=3){const Tk=d[k-1];for(let j=0;j<k-1;j++){const tr=document.createElement('tr');tr.innerHTML=`<td>${j+1}</td><td>${d[j].toFixed(4)}</td><td>${Math.log(Tk/d[j]).toFixed(6)}</td>`;el.termsBody.appendChild(tr);}}drawHistogram(neighborCache.map(v=>localMle(v,k)));}
-function drawHeroFrame(){const w=el.heroCanvas.width,h=el.heroCanvas.height;heroCtx.clearRect(0,0,w,h);heroCtx.fillStyle='#050812';heroCtx.fillRect(0,0,w,h);const line=state.manifoldType==='line';for(let i=0;i<state.points.length;i++){const p=state.points[i];let x=p.x*w,y=p.y*h;if(!prefersReducedMotion){const phase=(i*0.08+state.t*0.9);y+=Math.sin(phase)*(line?1.4:1.1);x+=Math.cos(phase*0.7)*0.8;}heroCtx.fillStyle='rgba(62,220,255,0.72)';heroCtx.beginPath();heroCtx.arc(x,y,2.5,0,Math.PI*2);heroCtx.fill();}const p=state.points[state.selectedIndex];if(p){const x=p.x*w,y=p.y*h;heroCtx.strokeStyle='rgba(142,123,255,.85)';heroCtx.lineWidth=3.2;heroCtx.beginPath();heroCtx.arc(x,y,15,0,Math.PI*2);heroCtx.stroke();heroCtx.fillStyle='rgba(255,184,77,1)';heroCtx.beginPath();heroCtx.arc(x,y,4.2,0,Math.PI*2);heroCtx.fill();}if(!prefersReducedMotion){state.t+=0.016;requestAnimationFrame(drawHeroFrame);}}
-function regenerate(){state.points=genPoints();state.selectedIndex=0;rebuildCache();updateMetrics();drawMain();if(prefersReducedMotion)drawHeroFrame();}
-function pickNearest(clientX,clientY){const r=el.simCanvas.getBoundingClientRect();const x=((clientX-r.left)/r.width)*el.simCanvas.width,y=((clientY-r.top)/r.height)*el.simCanvas.height;let best=0,bestD=Infinity;for(let i=0;i<state.points.length;i++){const p=state.points[i],d=Math.hypot(p.x*el.simCanvas.width-x,p.y*el.simCanvas.height-y);if(d<bestD){bestD=d;best=i;}}state.selectedIndex=best;updateMetrics();drawMain();}
-el.simCanvas.addEventListener('click',e=>pickNearest(e.clientX,e.clientY));el.simCanvas.addEventListener('keydown',e=>{if(e.key==='ArrowRight'||e.key==='ArrowDown'){state.selectedIndex=(state.selectedIndex+1)%state.points.length;updateMetrics();drawMain();e.preventDefault();}if(e.key==='ArrowLeft'||e.key==='ArrowUp'){state.selectedIndex=(state.selectedIndex-1+state.points.length)%state.points.length;updateMetrics();drawMain();e.preventDefault();}});el.manifoldType.addEventListener('change',()=>{state.manifoldType=el.manifoldType.value;regenerate();});el.nPoints.addEventListener('input',()=>{state.nPoints=Number(el.nPoints.value);regenerate();});el.kRange.addEventListener('input',()=>{state.k=Number(el.kRange.value);updateMetrics();drawMain();});el.noise.addEventListener('input',()=>{state.noise=Number(el.noise.value);regenerate();});el.outlier.addEventListener('input',()=>{state.outlierFrac=Number(el.outlier.value);regenerate();});el.regen.addEventListener('click',regenerate);
-regenerate(); if(!prefersReducedMotion) requestAnimationFrame(drawHeroFrame);
-let b=document.querySelector('#menu-trigger'),m=document.querySelector('.menu');b.addEventListener('click',()=>m.classList.toggle('hidden'));document.body.addEventListener('click',e=>{if(!b.contains(e.target))m.classList.add('hidden')});
+<header class="header"><nav class="nav"><div class="logo"><a href="https://ldomenichelli.github.io/" accesskey="h" title="lucia's notes (Alt + H)">lucia's notes</a><div class="logo-switches"><ul class="lang-switch"><li>|</li></ul></div></div><button id="menu-trigger" aria-haspopup="menu" aria-label="Menu Button"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentcolor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-menu"><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="18" x2="21" y2="18"/></svg></button><ul class="menu hidden"><li><a href="https://ldomenichelli.github.io/about/" title="about"><span>about</span></a></li><li><a href="https://ldomenichelli.github.io/posts/" title="notes"><span>notes</span></a></li><li><a href="https://ldomenichelli.github.io/projects/" title="projects"><span>projects</span></a></li><li><a href="https://ldomenichelli.github.io/random/" title="hobbies"><span>hobbies</span></a></li></ul></nav></header>
+<main class="main">
+  <article class="post-single cinematic-wrap">
+    <header class="post-header">
+      <div class="hero">
+        <span class="badge">Intrinsic Dimensionality · Levina–Bickel MLE</span>
+        <h1 class="post-title">Estimating manifold dimension from local distance ratios</h1>
+        <p class="subtle">All estimator math below is shown in LaTeX, and the values are computed from the currently displayed neighborhood.</p>
+      </div>
+    </header>
+    <div class="post-content">
+      <div class="layout">
+        <section class="panel" aria-labelledby="what-is-id">
+          <h2 id="what-is-id">Local estimator</h2>
+          <div class="formula">$$\hat{m}_k(x)=\left[\frac{1}{k-1}\sum_{j=1}^{k-1}\log\frac{T_k(x)}{T_j(x)}\right]^{-1}$$</div>
+          <p>Here $T_j(x)$ is the $j$-th nearest-neighbor distance from $x$. The point inspector computes every term in the sum and updates $\hat{m}_k(x)$ live.</p>
+          <div class="formula">$$\hat{m}_{\text{global}}(k)=\frac{1}{N}\sum_{i=1}^{N}\hat{m}_k(x_i)$$</div>
+          <p>The aggregate panel estimates a dataset-level dimension, and reports an interquartile spread to show instability.</p>
+        </section>
+        <aside class="panel" aria-labelledby="failure-modes">
+          <h2 id="failure-modes">Failure-mode controls</h2>
+          <p class="subtle">Use sliders to stress the assumptions behind local Poisson-like neighbor behavior.</p>
+          <ul>
+            <li><strong>Boundary clipping:</strong> clips point coordinates to $[\beta,1-\beta]^2$, increasing boundary bias.</li>
+            <li><strong>Outliers:</strong> replaces a fraction of points with uniform noise in the ambient square.</li>
+            <li><strong>Noise:</strong> adds isotropic Gaussian perturbations.</li>
+          </ul>
+          <p class="warning">Interpret estimates as local summaries, not a single “true” number across all scales.</p>
+        </aside>
+      </div>
+
+      <section class="panel" aria-labelledby="m3-title" style="margin-top:16px;">
+        <h2 id="m3-title">Milestone 3 · Local + aggregate views</h2>
+        <div class="controls" aria-label="Generator controls">
+          <div class="control"><label for="manifoldType">Manifold type</label><select id="manifoldType"><option value="line">Line (1D)</option><option value="circle">Circle (1D)</option><option value="plane">Plane (2D)</option></select></div>
+          <div class="control"><label for="sampleSize">Sample size: <span id="sampleSizeValue">180</span></label><input id="sampleSize" type="range" min="80" max="480" step="20" value="180"></div>
+          <div class="control"><label for="kNeighbors">$k$: <span id="kNeighborsValue">12</span></label><input id="kNeighbors" type="range" min="3" max="48" step="1" value="12"></div>
+          <div class="control"><label for="noise">Noise $\sigma$: <span id="noiseValue">0.020</span></label><input id="noise" type="range" min="0" max="0.12" step="0.005" value="0.02"></div>
+          <div class="control"><label for="boundary">Boundary clip $\beta$: <span id="boundaryValue">0.000</span></label><input id="boundary" type="range" min="0" max="0.18" step="0.01" value="0"></div>
+          <div class="control"><label for="outliers">Outlier fraction: <span id="outlierValue">0.00</span></label><input id="outliers" type="range" min="0" max="0.40" step="0.01" value="0"></div>
+          <div class="control"><button id="regenerate" type="button">Regenerate sample</button></div>
+        </div>
+
+        <div class="demo-layout">
+          <div>
+            <canvas id="manifoldCanvas" width="700" height="500" tabindex="0" aria-label="Toy manifold points and selected neighborhood"></canvas>
+            <p class="subtle">Click to inspect a point. Keyboard: Arrow keys move selection; Home/End jump to first/last point.</p>
+          </div>
+          <div>
+            <div class="metrics">
+              <div class="metric"><span class="k">Selected point</span><span id="selectedLabel" class="v">#1</span></div>
+              <div class="metric"><span class="k">Local $\hat{m}_k(x)$</span><span id="localMleValue" class="v">—</span></div>
+              <div class="metric"><span class="k">$T_k(x)$</span><span id="tkValue" class="v">—</span></div>
+              <div class="metric"><span class="k">Global mean</span><span id="globalMean" class="v">—</span></div>
+              <div class="metric"><span class="k">Global median</span><span id="globalMedian" class="v">—</span></div>
+              <div class="metric"><span class="k">IQR</span><span id="globalIqr" class="v">—</span></div>
+            </div>
+            <div class="terms" style="margin-top:10px;"><table><thead><tr><th>$j$</th><th>$T_j(x)$</th><th>$\log(T_k/T_j)$</th></tr></thead><tbody id="termsBody"></tbody></table></div>
+          </div>
+        </div>
+
+        <div class="aggregate-layout">
+          <div class="hist-wrap">
+            <h3 style="margin:.1rem 0 .4rem;">Aggregate estimate distribution</h3>
+            <canvas id="histCanvas" width="600" height="260" aria-label="Histogram of local intrinsic-dimension estimates"></canvas>
+          </div>
+          <div class="hist-wrap">
+            <h3 style="margin:.1rem 0 .4rem;">Live status</h3>
+            <p id="statusText" aria-live="polite" class="subtle">Ready.</p>
+            <div class="formula">$$\text{IQR}=Q_{0.75}(\hat{m}_k)-Q_{0.25}(\hat{m}_k)$$</div>
+            <p class="subtle">Large IQR values indicate unstable local scaling or mixed regimes.</p>
+          </div>
+        </div>
+      </section>
+    </div>
+  </article>
+</main>
+<script type="module">
+  import { localMleFromSortedDistances } from '/assets/js/id-estimator.js';
+
+  // Minimal app state: one object, no hidden globals.
+  const state = { manifoldType: 'line', sampleSize: 180, k: 12, noise: 0.02, boundary: 0, outliers: 0, points: [], neighbors: [], selectedIndex: 0 };
+
+  const el = {
+    menuTrigger: document.querySelector('#menu-trigger'), menu: document.querySelector('.menu'),
+    manifoldType: document.querySelector('#manifoldType'), sampleSize: document.querySelector('#sampleSize'), sampleSizeValue: document.querySelector('#sampleSizeValue'),
+    kNeighbors: document.querySelector('#kNeighbors'), kNeighborsValue: document.querySelector('#kNeighborsValue'), noise: document.querySelector('#noise'), noiseValue: document.querySelector('#noiseValue'),
+    boundary: document.querySelector('#boundary'), boundaryValue: document.querySelector('#boundaryValue'), outliers: document.querySelector('#outliers'), outlierValue: document.querySelector('#outlierValue'), regenerate: document.querySelector('#regenerate'),
+    canvas: document.querySelector('#manifoldCanvas'), histCanvas: document.querySelector('#histCanvas'), termsBody: document.querySelector('#termsBody'),
+    selectedLabel: document.querySelector('#selectedLabel'), localMleValue: document.querySelector('#localMleValue'), tkValue: document.querySelector('#tkValue'),
+    globalMean: document.querySelector('#globalMean'), globalMedian: document.querySelector('#globalMedian'), globalIqr: document.querySelector('#globalIqr'), statusText: document.querySelector('#statusText')
+  };
+  const ctx = el.canvas.getContext('2d');
+  const histCtx = el.histCanvas.getContext('2d');
+
+  const randn = () => { const u = Math.max(1e-12, Math.random()); const v = Math.random(); return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v); };
+
+  function clamp01(v, margin = 0) { return Math.min(1 - margin, Math.max(margin, v)); }
+
+  function sortedNeighborsFor(i, pts) {
+    const p = pts[i];
+    const arr = [];
+    for (let j = 0; j < pts.length; j += 1) {
+      if (i === j) continue;
+      arr.push({ j, d: Math.hypot(p.x - pts[j].x, p.y - pts[j].y) });
+    }
+    arr.sort((a, b) => a.d - b.d);
+    return arr;
+  }
+
+  function makeBasePoint(i, n) {
+    const t = i / Math.max(1, n - 1);
+    if (state.manifoldType === 'line') return { x: 0.12 + 0.76 * t, y: 0.5 };
+    if (state.manifoldType === 'circle') { const a = 2 * Math.PI * t; return { x: 0.5 + 0.30 * Math.cos(a), y: 0.5 + 0.30 * Math.sin(a) }; }
+    return { x: 0.1 + 0.8 * Math.random(), y: 0.1 + 0.8 * Math.random() };
+  }
+
+  function rebuildDataset() {
+    const pts = [];
+    for (let i = 0; i < state.sampleSize; i += 1) {
+      let p = makeBasePoint(i, state.sampleSize);
+      p = { x: p.x + randn() * state.noise, y: p.y + randn() * state.noise };
+      p = { x: clamp01(p.x, state.boundary), y: clamp01(p.y, state.boundary) };
+      if (Math.random() < state.outliers) p = { x: 0.02 + 0.96 * Math.random(), y: 0.02 + 0.96 * Math.random() };
+      pts.push(p);
+    }
+    state.points = pts;
+    state.neighbors = pts.map((_, i) => sortedNeighborsFor(i, pts));
+    state.selectedIndex = Math.min(state.selectedIndex, Math.max(0, pts.length - 1));
+    syncControls();
+    drawMain();
+    refreshAllMetrics();
+  }
+
+  function syncControls() {
+    el.sampleSizeValue.textContent = String(state.sampleSize);
+    el.kNeighborsValue.textContent = String(state.k);
+    el.noiseValue.textContent = state.noise.toFixed(3);
+    el.boundaryValue.textContent = state.boundary.toFixed(3);
+    el.outlierValue.textContent = state.outliers.toFixed(2);
+  }
+
+  function drawMain() {
+    const w = el.canvas.width; const h = el.canvas.height;
+    ctx.clearRect(0, 0, w, h);
+    ctx.fillStyle = '#080d18'; ctx.fillRect(0, 0, w, h);
+    const idx = state.selectedIndex;
+    const p = state.points[idx];
+    if (!p) return;
+    const k = Math.min(state.k, state.neighbors[idx].length);
+
+    ctx.fillStyle = 'rgba(88,214,255,0.9)';
+    for (const q of state.points) { ctx.beginPath(); ctx.arc(q.x * w, q.y * h, 2.8, 0, Math.PI * 2); ctx.fill(); }
+
+    for (let i = 0; i < k; i += 1) {
+      const r = state.neighbors[idx][i].d * Math.min(w, h);
+      ctx.strokeStyle = i === k - 1 ? 'rgba(255,191,102,0.9)' : 'rgba(155,140,255,0.58)';
+      ctx.lineWidth = i === k - 1 ? 2.8 : 1.5;
+      ctx.beginPath(); ctx.arc(p.x * w, p.y * h, r, 0, Math.PI * 2); ctx.stroke();
+    }
+
+    for (let i = 0; i < k; i += 1) {
+      const q = state.points[state.neighbors[idx][i].j];
+      ctx.fillStyle = 'rgba(155,140,255,1)'; ctx.beginPath(); ctx.arc(q.x * w, q.y * h, 4, 0, Math.PI * 2); ctx.fill();
+    }
+
+    ctx.fillStyle = 'rgba(255,191,102,1)'; ctx.beginPath(); ctx.arc(p.x * w, p.y * h, 5.2, 0, Math.PI * 2); ctx.fill();
+  }
+
+  function summarize(values) {
+    const v = values.filter(Number.isFinite).sort((a, b) => a - b);
+    if (!v.length) return { mean: NaN, median: NaN, iqr: NaN, arr: [] };
+    const q = (p) => v[Math.floor((v.length - 1) * p)];
+    const mean = v.reduce((a, b) => a + b, 0) / v.length;
+    return { mean, median: q(0.5), iqr: q(0.75) - q(0.25), arr: v };
+  }
+
+  function drawHistogram(vals) {
+    const w = el.histCanvas.width; const h = el.histCanvas.height;
+    histCtx.clearRect(0, 0, w, h);
+    histCtx.fillStyle = '#080d18'; histCtx.fillRect(0, 0, w, h);
+    const clean = vals.filter(Number.isFinite);
+    if (!clean.length) return;
+    const min = Math.max(0, Math.min(...clean));
+    const max = Math.max(...clean, min + 1e-6);
+    const bins = 16;
+    const counts = new Array(bins).fill(0);
+    for (const x of clean) {
+      const bi = Math.min(bins - 1, Math.floor(((x - min) / (max - min)) * bins));
+      counts[bi] += 1;
+    }
+    const maxC = Math.max(...counts, 1);
+    const bw = (w - 46) / bins;
+    histCtx.strokeStyle = 'rgba(61,84,122,0.9)'; histCtx.strokeRect(30, 16, w - 44, h - 34);
+    for (let i = 0; i < bins; i += 1) {
+      const barH = (counts[i] / maxC) * (h - 50);
+      histCtx.fillStyle = 'rgba(88,214,255,0.75)';
+      histCtx.fillRect(32 + i * bw, h - 20 - barH, bw - 2, barH);
+    }
+  }
+
+  function refreshAllMetrics() {
+    const idx = state.selectedIndex;
+    const nei = state.neighbors[idx] || [];
+    const distances = nei.map((x) => x.d);
+    const k = Math.min(state.k, distances.length);
+    const local = localMleFromSortedDistances(distances, k);
+
+    el.selectedLabel.textContent = `#${idx + 1}`;
+    el.localMleValue.textContent = Number.isFinite(local) ? local.toFixed(4) : '—';
+    el.tkValue.textContent = k > 0 ? distances[k - 1].toFixed(4) : '—';
+
+    el.termsBody.innerHTML = '';
+    if (k >= 2) {
+      const Tk = distances[k - 1];
+      for (let j = 0; j < k - 1; j += 1) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${j + 1}</td><td>${distances[j].toFixed(5)}</td><td>${Math.log(Tk / distances[j]).toFixed(6)}</td>`;
+        el.termsBody.appendChild(tr);
+      }
+    }
+
+    const localVals = state.neighbors.map((arr) => localMleFromSortedDistances(arr.map((x) => x.d), k));
+    const summary = summarize(localVals);
+    el.globalMean.textContent = Number.isFinite(summary.mean) ? summary.mean.toFixed(4) : '—';
+    el.globalMedian.textContent = Number.isFinite(summary.median) ? summary.median.toFixed(4) : '—';
+    el.globalIqr.textContent = Number.isFinite(summary.iqr) ? summary.iqr.toFixed(4) : '—';
+
+    drawHistogram(localVals);
+    el.statusText.textContent = `n=${state.sampleSize}, manifold=${state.manifoldType}, k=${state.k}, noise=${state.noise.toFixed(3)}, boundary=${state.boundary.toFixed(3)}, outliers=${state.outliers.toFixed(2)}.`;
+  }
+
+  function pickPoint(clientX, clientY) {
+    const r = el.canvas.getBoundingClientRect();
+    const x = (clientX - r.left) / r.width;
+    const y = (clientY - r.top) / r.height;
+    let best = 0; let bestDist = Infinity;
+    for (let i = 0; i < state.points.length; i += 1) {
+      const d = Math.hypot(state.points[i].x - x, state.points[i].y - y);
+      if (d < bestDist) { bestDist = d; best = i; }
+    }
+    state.selectedIndex = best;
+    drawMain();
+    refreshAllMetrics();
+  }
+
+  el.manifoldType.addEventListener('change', () => { state.manifoldType = el.manifoldType.value; rebuildDataset(); });
+  el.sampleSize.addEventListener('input', () => { state.sampleSize = Number(el.sampleSize.value); rebuildDataset(); });
+  el.kNeighbors.addEventListener('input', () => { state.k = Number(el.kNeighbors.value); syncControls(); drawMain(); refreshAllMetrics(); });
+  el.noise.addEventListener('input', () => { state.noise = Number(el.noise.value); rebuildDataset(); });
+  el.boundary.addEventListener('input', () => { state.boundary = Number(el.boundary.value); rebuildDataset(); });
+  el.outliers.addEventListener('input', () => { state.outliers = Number(el.outliers.value); rebuildDataset(); });
+  el.regenerate.addEventListener('click', rebuildDataset);
+
+  el.canvas.addEventListener('click', (e) => pickPoint(e.clientX, e.clientY));
+  el.canvas.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') state.selectedIndex = (state.selectedIndex + 1) % state.points.length;
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') state.selectedIndex = (state.selectedIndex - 1 + state.points.length) % state.points.length;
+    else if (e.key === 'Home') state.selectedIndex = 0;
+    else if (e.key === 'End') state.selectedIndex = state.points.length - 1;
+    else return;
+    e.preventDefault();
+    drawMain();
+    refreshAllMetrics();
+  });
+
+  el.menuTrigger.addEventListener('click', () => el.menu.classList.toggle('hidden'));
+  document.body.addEventListener('click', (e) => { if (!el.menuTrigger.contains(e.target)) el.menu.classList.add('hidden'); });
+
+  rebuildDataset();
 </script>
 </body>
 </html>

--- a/public/assets/js/id-estimator.js
+++ b/public/assets/js/id-estimator.js
@@ -1,0 +1,41 @@
+/**
+ * Levina–Bickel MLE helpers.
+ * Kept dependency-free so both browser and Node tests can use the same code.
+ */
+
+export function localMleFromSortedDistances(sortedDistances, k) {
+  if (!Array.isArray(sortedDistances) || sortedDistances.length < 2) return NaN;
+  const kEff = Math.max(2, Math.min(k, sortedDistances.length));
+  const Tk = sortedDistances[kEff - 1];
+  if (!(Tk > 0)) return NaN;
+
+  let sum = 0;
+  for (let j = 0; j < kEff - 1; j += 1) {
+    const Tj = sortedDistances[j];
+    if (!(Tj > 0) || Tj > Tk) return NaN;
+    sum += Math.log(Tk / Tj);
+  }
+  const avg = sum / (kEff - 1);
+  return avg > 0 ? 1 / avg : NaN;
+}
+
+export function pairwiseSortedDistances(points) {
+  return points.map((p, i) => {
+    const ds = [];
+    for (let j = 0; j < points.length; j += 1) {
+      if (i === j) continue;
+      const q = points[j];
+      ds.push(Math.hypot(p.x - q.x, p.y - q.y));
+    }
+    ds.sort((a, b) => a - b);
+    return ds;
+  });
+}
+
+export function datasetMle(points, k) {
+  const cache = pairwiseSortedDistances(points);
+  const vals = cache.map((d) => localMleFromSortedDistances(d, k)).filter(Number.isFinite);
+  if (!vals.length) return NaN;
+  return vals.reduce((a, b) => a + b, 0) / vals.length;
+}
+

--- a/public/projects/index.html
+++ b/public/projects/index.html
@@ -42,7 +42,7 @@
 <div class="post-content">
 <p>A few things I'm working on:</p>
 <ul>
-<li><strong>Intrinsic Dimensionality</strong> – Studying compact latent structures in language representations and how they evolve across layers.</li>
+<li><strong><a href="/projects/intrinsic-dimensionality/">Intrinsic Dimensionality (Levina–Bickel MLE demo)</a></strong> – Interactive explainer for local neighbor-based intrinsic dimension estimation.</li>
 </ul>
 <p>
 <img src="/random/tea/img/tea.jpeg" alt="Cute teacup photo for the Intrinsic Dimensionality project" style="max-width:320px;width:100%;border-radius:14px;display:block;margin-top:12px;">

--- a/public/projects/intrinsic-dimensionality/index.html
+++ b/public/projects/intrinsic-dimensionality/index.html
@@ -5,8 +5,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
   <meta name="robots" content="index, follow">
-  <title>Intrinsic Dimensionality methods | lucia's notes</title>
-  <meta name="description" content="Cinematic interactive explainer for intrinsic dimensionality (Levina–Bickel MLE).">
+  <title>Levina–Bickel MLE Intrinsic Dimensionality | lucia's notes</title>
+  <meta name="description" content="Interactive explainer for Levina–Bickel MLE intrinsic dimensionality with local and aggregate k-NN views.">
   <meta name="author" content="Lucia">
   <link rel="canonical" href="https://ldomenichelli.github.io/projects/intrinsic-dimensionality/">
   <link crossorigin="anonymous" href="/assets/css/stylesheet.5ad9b1caa92e4cea83ebcd3088e97362f239b07d8144490aaf0bc1d6bd89cd17.css" integrity="sha256-WtmxyqkuTOqD680wiOlzYvI5sH2BREkKrwvB1r2JzRc=" rel="preload stylesheet" as="style">
@@ -15,71 +15,311 @@
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js" integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4" crossorigin="anonymous"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js" integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa" crossorigin="anonymous" onload='renderMathInElement(document.body,{delimiters:[{left:"$$",right:"$$",display:true},{left:"$",right:"$",display:false}]})'></script>
   <style>
-    :root{--bg:#000000;--panel:#0B0D12;--panel-2:#121723;--text:#EAF2FF;--muted:#B5C5E0;--cyan:#3EDCFF;--violet:#8E7BFF;--amber:#FFB84D;--border:#273045;--focus:#62E6FF}
-    body#top.dark{background:var(--bg);color:var(--text)} .main{max-width:1220px} .post-content{max-width:74ch;line-height:1.75}
-    .cinematic-wrap{position:relative;overflow:hidden}
-    .ambient-glow{position:absolute;inset:-220px auto auto -140px;width:520px;height:520px;border-radius:50%;background:radial-gradient(circle,rgba(62,220,255,.18),rgba(62,220,255,0));pointer-events:none;filter:blur(2px)}
-    .ambient-glow.violet{inset:140px -170px auto auto;background:radial-gradient(circle,rgba(142,123,255,.16),rgba(142,123,255,0))}
-    .hero-card,.panel{position:relative;background:linear-gradient(165deg,var(--panel),var(--panel-2));border:1px solid var(--border);border-radius:16px}
-    .hero-card{padding:18px;margin:14px 0 18px;overflow:hidden}
-    .hero-grid{display:grid;grid-template-columns:1.15fr .85fr;gap:16px;align-items:center}
-    .hero-title{font-size:clamp(1.25rem,3.2vw,2rem);margin:.2rem 0 .7rem}
-    .badge{display:inline-block;border:1px solid #3d4a6b;color:var(--cyan);padding:3px 10px;border-radius:999px;font-size:.8rem;letter-spacing:.02em}
-    .layout{display:grid;grid-template-columns:1.35fr .85fr;gap:16px;align-items:start}
-    .panel{padding:16px} .panel h3{margin:.2rem 0 .6rem;font-size:1.1rem} .subtle{color:var(--muted);font-size:.94rem} .result{font-weight:700}
-    .controls{display:grid;gap:10px;margin-top:10px} .controls-grid{display:grid;gap:12px;grid-template-columns:repeat(2,minmax(0,1fr))}
-    label{font-size:.92rem;color:var(--text)} input[type="range"],select{width:100%} select,input[type="range"]{accent-color:var(--cyan)}
-    select{background:#0D1320;color:var(--text);border:1px solid #3A4A73;border-radius:10px;padding:8px}
-    .btn{background:linear-gradient(180deg,#11293a,#0b1b2a);color:var(--text);border:1px solid #2e5972;border-radius:10px;padding:.6rem .9rem;cursor:pointer;font-weight:600;transition:transform .18s ease, box-shadow .18s ease, border-color .18s ease}
-    .btn:hover{transform:translateY(-1px);border-color:var(--cyan);box-shadow:0 0 0 2px rgba(62,220,255,.22)}
-    .btn:focus-visible,select:focus-visible,input:focus-visible,canvas:focus-visible{outline:2px solid var(--focus);outline-offset:2px;box-shadow:0 0 0 3px rgba(98,230,255,.28)}
-    canvas{width:100%;height:auto;border:1.5px solid #3B4B76;border-radius:12px;background:#050812}
-    .formula-sticky{position:sticky;top:90px} .formula-eq{padding:10px;border:1px solid #394766;border-radius:10px;background:rgba(9,16,28,.75);overflow:auto}
-    .passages li{margin:.5rem 0} .warning{color:var(--amber);font-weight:600}
-    table{width:100%;border-collapse:collapse;margin-top:8px} th,td{border-bottom:1px solid #2c3752;padding:6px 4px;text-align:left;font-size:.92rem}
-    .legend{display:flex;flex-wrap:wrap;gap:8px;margin-top:8px} .legend span{font-size:.84rem;border:1px solid #334568;border-radius:999px;padding:2px 9px}
-    @media (prefers-reduced-motion: reduce){*{animation:none !important;transition:none !important;scroll-behavior:auto !important}}
-    @media (max-width:980px){.hero-grid,.layout{grid-template-columns:1fr}.formula-sticky{position:static}.controls-grid{grid-template-columns:1fr}}
+    :root { --bg:#090c14; --panel:#111827; --panel-2:#182236; --text:#e9f1ff; --muted:#b4c3df; --cyan:#58d6ff; --violet:#9b8cff; --border:#334667; --focus:#7de6ff; --amber:#ffbf66; }
+    body#top.dark { background:var(--bg); color:var(--text); }
+    .main { max-width:1220px; } .post-content { max-width:98ch; line-height:1.68; }
+    .hero,.panel{background:linear-gradient(165deg,var(--panel),var(--panel-2));border:1px solid var(--border);border-radius:16px}
+    .hero{padding:20px;margin:16px 0 18px}.hero h1{margin:0 0 10px;font-size:clamp(1.35rem,3.2vw,2rem)}
+    .badge{display:inline-block;border:1px solid #3f5a80;color:var(--cyan);border-radius:999px;padding:4px 10px;font-size:.82rem;margin-bottom:8px}
+    .layout{display:grid;grid-template-columns:1.2fr .8fr;gap:16px;align-items:start}
+    .panel{padding:16px}.panel h2{margin-top:.1rem;font-size:1.1rem}.subtle{color:var(--muted)}
+    .formula{border:1px solid #3a4d74;background:rgba(12,20,33,.75);border-radius:12px;padding:10px;overflow:auto}
+
+    .controls{display:grid;gap:10px;grid-template-columns:repeat(3,minmax(0,1fr));margin-bottom:12px}
+    .control{display:grid;gap:4px}.control label{font-size:.9rem}
+    input[type="range"],select,button{width:100%;accent-color:var(--cyan)}
+    select,button{background:#0f1523;color:var(--text);border:1px solid #3b4b6e;border-radius:8px;padding:8px}
+    button{cursor:pointer;font-weight:600}
+    button:hover{border-color:var(--cyan)}
+
+    .demo-layout{display:grid;grid-template-columns:1.05fr .95fr;gap:12px}
+    canvas{width:100%;height:auto;border:1px solid #3b4b6e;border-radius:12px;background:#080d18}
+    .metrics{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px}
+    .metric{border:1px solid #324568;background:rgba(9,15,27,.7);border-radius:10px;padding:8px}
+    .metric .k{display:block;font-size:.77rem;color:var(--muted)} .metric .v{font-size:1rem;font-weight:700}
+    .terms{max-height:220px;overflow:auto;border:1px solid #2f4368;border-radius:10px}
+    table{width:100%;border-collapse:collapse;font-size:.86rem} th,td{padding:6px;border-bottom:1px solid #2b3d61;text-align:left}
+
+    .aggregate-layout{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:12px}
+    .hist-wrap{border:1px solid #2f4368;border-radius:10px;padding:8px;background:rgba(8,14,25,.7)}
+    .warning{color:var(--amber);font-size:.88rem}
+
+    a:focus-visible,button:focus-visible,input:focus-visible,select:focus-visible,canvas:focus-visible{outline:2px solid var(--focus);outline-offset:2px;box-shadow:0 0 0 3px rgba(125,230,255,.28)}
+    @media (max-width:1024px){.controls{grid-template-columns:repeat(2,minmax(0,1fr))}.layout,.demo-layout,.aggregate-layout{grid-template-columns:1fr}.metrics{grid-template-columns:repeat(2,minmax(0,1fr))}}
+    @media (max-width:640px){.controls,.metrics{grid-template-columns:1fr}}
   </style>
 <script src="/assets/js/analytics.js" async></script></head>
 <body class="dark" id="top">
-<header class="header"><nav class="nav"><div class="logo"><a href="https://ldomenichelli.github.io/" accesskey="h" title="lucia's notes (Alt + H)">lucia's notes</a><div class="logo-switches"><ul class="lang-switch"><li>|</li></ul></div></div><button id="menu-trigger" aria-haspopup="menu" aria-label="Menu Button"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentcolor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-menu"><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="18" x2="21" y2="18"/></svg></button><ul class="menu hidden"><li><a href="https://ldomenichelli.github.io/about/" title="about"><span>about</span></a></li><li><a href="https://ldomenichelli.github.io/posts/" title="notes"><span>notes</span></a></li><li><a href="https://ldomenichelli.github.io/projects/" title="projects"><span class="active">projects</span></a></li><li><a href="https://ldomenichelli.github.io/random/" title="hobbies"><span>hobbies</span></a></li></ul></nav></header>
-<main class="main cinematic-wrap"><div class="ambient-glow"></div><div class="ambient-glow violet"></div>
-<article class="post-single"><header class="post-header"><div class="breadcrumbs"><a href="/projects/">Projects</a></div><h1 class="post-title">Intrinsic Dimensionality methods</h1></header>
-<div class="post-content">
-<section class="hero-card" aria-labelledby="hero-title"><div class="hero-grid"><div><span class="badge">Research demo</span><h2 id="hero-title" class="hero-title">Cinematic explainer of local and aggregate intrinsic dimension</h2><p class="subtle">Observe how nearest-neighbor geometry, noise, and outliers alter the Levina–Bickel estimate. The animation and controls below are tuned for high-contrast, technical readability.</p><div class="legend"><span style="color:var(--cyan)">Cyan: data manifold</span><span style="color:var(--violet)">Violet: highlighted neighbors</span><span style="color:var(--amber)">Amber: selected point</span></div></div><div><canvas id="heroCanvas" width="620" height="280" aria-label="Animated manifold point cloud"></canvas></div></div></section>
-<div class="layout">
-<section class="panel" aria-labelledby="nn-title"><h3 id="nn-title">Nearest-neighbor visualization</h3><p class="subtle">Click a point to inspect local geometry. Controls update the toy manifold generator and highlight failure modes.</p>
-<div class="controls controls-grid"><div><label for="manifoldType">Manifold type</label><select id="manifoldType" aria-label="Manifold type"><option value="line">Line</option><option value="plane" selected>Plane</option></select></div><div><label for="kRange">k neighbors: <strong id="kValue">8</strong></label><input id="kRange" type="range" min="3" max="30" value="8"></div><div><label for="nPoints">Points: <strong id="nPointsValue">160</strong></label><input id="nPoints" type="range" min="50" max="340" value="160"></div><div><label for="noiseSlider">Noise std: <strong id="noiseValue">0.02</strong></label><input id="noiseSlider" type="range" min="0" max="0.12" step="0.005" value="0.02"></div><div><label for="outlierSlider">Outlier fraction: <strong id="outlierValue">0.00</strong></label><input id="outlierSlider" type="range" min="0" max="0.5" step="0.02" value="0"></div><div style="display:flex;align-items:flex-end"><button class="btn" id="regenBtn" aria-label="Regenerate manifold" style="width:100%">Regenerate manifold</button></div></div>
-<p id="status" class="subtle" aria-live="polite"></p>
-<canvas id="simCanvas" width="840" height="460" tabindex="0" aria-label="Point cloud inspector. Click or use arrow keys."></canvas>
-<p class="subtle" style="margin-top:8px">Thicker circles mark neighbor radii $T_1,\dots,T_k$ with strong focus visibility.</p>
-<table><thead><tr><th>j</th><th>$T_j$</th><th>$\log(T_k/T_j)$</th></tr></thead><tbody id="termsBody"></tbody></table></section>
-<aside class="formula-sticky"><section class="panel" aria-labelledby="formula-title"><h3 id="formula-title">Formula + derivation passages</h3><div class="formula-eq">$$\hat m_k(x)=\left[\frac{1}{k-1}\sum_{j=1}^{k-1}\log\frac{T_k(x)}{T_j(x)}\right]^{-1},\quad \hat m=\frac{1}{n}\sum_{i=1}^{n}\hat m_k(x_i)$$</div><ol class="passages subtle"><li>Count neighbors in $S_x(t)$: $$N(t,x)=\sum_i \mathbf{1}\{X_i\in S_x(t)\}$$</li><li>Assume local Poisson intensity: $$\lambda(t)=f(x)V(m)mt^{m-1}$$</li><li>Build log-likelihood and solve for $m$.</li><li>Switch from radius-$R$ form to practical $k$-NN form.</li></ol><p class="warning">Warning: high noise / many outliers can inflate or destabilize estimates.</p></section>
-<section class="panel" aria-labelledby="agg-title"><h3 id="agg-title">Histogram + aggregate estimates</h3><p class="result">Local MLE: <span id="mleValue">—</span></p><p class="result">Dataset average MLE: <span id="globalMleValue">—</span></p><p class="subtle">k-range average <span id="kRangeSummary">k=4..12</span>: <span id="aggRangeValue">—</span></p><canvas id="histCanvas" width="520" height="260" aria-label="Histogram of local MLE estimates"></canvas></section></aside>
-</div>
-<p><a href="/projects/">← Back to Projects</a></p></div></article></main>
-<script>
-const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-const state = { points: [], selectedIndex: 0, manifoldType: 'plane', nPoints: 160, k: 8, noise: 0.02, outlierFrac: 0, t: 0 };
-const el = {manifoldType: document.getElementById('manifoldType'), nPoints: document.getElementById('nPoints'), nPointsValue: document.getElementById('nPointsValue'), kRange: document.getElementById('kRange'), kValue: document.getElementById('kValue'), noise: document.getElementById('noiseSlider'), noiseValue: document.getElementById('noiseValue'), outlier: document.getElementById('outlierSlider'), outlierValue: document.getElementById('outlierValue'), regen: document.getElementById('regenBtn'), status: document.getElementById('status'), mle: document.getElementById('mleValue'), gmle: document.getElementById('globalMleValue'), agg: document.getElementById('aggRangeValue'), kSummary: document.getElementById('kRangeSummary'), termsBody: document.getElementById('termsBody'), simCanvas: document.getElementById('simCanvas'), heroCanvas: document.getElementById('heroCanvas'), histCanvas: document.getElementById('histCanvas')};
-const simCtx = el.simCanvas.getContext('2d'); const heroCtx = el.heroCanvas.getContext('2d'); const histCtx = el.histCanvas.getContext('2d'); let neighborCache=[];
-function randn(){let u=0,v=0;while(!u)u=Math.random();while(!v)v=Math.random();return Math.sqrt(-2*Math.log(u))*Math.cos(2*Math.PI*v)}
-function genPoints(){const pts=[];const nOut=Math.floor(state.nPoints*state.outlierFrac);const nCore=state.nPoints-nOut;if(state.manifoldType==='line'){const a=Math.PI/6;for(let i=0;i<nCore;i++){const t=0.12+0.76*Math.random();const x=0.5+(t-0.5)*Math.cos(a)+state.noise*randn();const y=0.5+(t-0.5)*Math.sin(a)+state.noise*randn();if(x>.02&&x<.98&&y>.02&&y<.98)pts.push({x,y});}}else{for(let i=0;i<nCore;i++){let x=0.08+0.84*Math.random()+state.noise*0.4*randn();let y=0.08+0.84*Math.random()+state.noise*0.4*randn();x=Math.max(.02,Math.min(.98,x));y=Math.max(.02,Math.min(.98,y));pts.push({x,y});}}for(let i=0;i<nOut;i++)pts.push({x:Math.random(),y:Math.random()});return pts;}
-function distancesFrom(i,canvas){const p=state.points[i],w=canvas.width,h=canvas.height;return state.points.map((q,j)=>({j,d:Math.hypot((q.x-p.x)*w,(q.y-p.y)*h)})).filter(o=>o.j!==i).sort((a,b)=>a.d-b.d)}
-function localMle(sorted,k){if(k<3||sorted.length<k)return NaN;const Tk=sorted[k-1];let s=0;for(let j=0;j<k-1;j++)s+=Math.log(Tk/sorted[j]);return 1/(s/(k-1));}
-function rebuildCache(){neighborCache=[];for(let i=0;i<state.points.length;i++)neighborCache.push(distancesFrom(i,el.simCanvas).map(o=>o.d));}
-function datasetAvg(k){const vals=[];for(const d of neighborCache){const m=localMle(d,k);if(Number.isFinite(m))vals.push(m);}return vals.length?vals.reduce((a,b)=>a+b,0)/vals.length:NaN}
-function kRangeAverage(){const k1=Math.max(3,state.k-4),k2=Math.min(30,state.k+4,neighborCache[0]?.length||state.k);let sum=0,c=0;for(let k=k1;k<=k2;k++){const m=datasetAvg(k);if(Number.isFinite(m)){sum+=m;c++;}}el.kSummary.textContent=`k=${k1}..${k2}`;return c?sum/c:NaN;}
-function drawMain(){const w=el.simCanvas.width,h=el.simCanvas.height;simCtx.clearRect(0,0,w,h);const g=simCtx.createLinearGradient(0,0,w,h);g.addColorStop(0,'#070D19');g.addColorStop(1,'#050812');simCtx.fillStyle=g;simCtx.fillRect(0,0,w,h);const i=state.selectedIndex,p=state.points[i];if(!p)return;const sorted=distancesFrom(i,el.simCanvas),k=Math.min(state.k,sorted.length),ax=p.x*w,ay=p.y*h;simCtx.fillStyle='rgba(62,220,255,0.95)';for(const q of state.points){simCtx.beginPath();simCtx.arc(q.x*w,q.y*h,3.1,0,Math.PI*2);simCtx.fill();}for(let j=0;j<k;j++){const r=sorted[j].d;simCtx.strokeStyle=j===k-1?'rgba(255,184,77,.88)':'rgba(142,123,255,.68)';simCtx.lineWidth=j===k-1?3.2:2.2;simCtx.beginPath();simCtx.arc(ax,ay,r,0,Math.PI*2);simCtx.stroke();}for(let j=0;j<k;j++){const q=state.points[sorted[j].j];simCtx.fillStyle='rgba(142,123,255,0.98)';simCtx.beginPath();simCtx.arc(q.x*w,q.y*h,4.4,0,Math.PI*2);simCtx.fill();}simCtx.fillStyle='rgba(255,184,77,1)';simCtx.beginPath();simCtx.arc(ax,ay,6.3,0,Math.PI*2);simCtx.fill();}
-function drawHistogram(values){const w=el.histCanvas.width,h=el.histCanvas.height;histCtx.clearRect(0,0,w,h);histCtx.fillStyle='#050812';histCtx.fillRect(0,0,w,h);const clean=values.filter(Number.isFinite);if(!clean.length)return;const min=Math.max(0,Math.min(...clean)),max=Math.max(...clean,min+1e-6),bins=14;const counts=new Array(bins).fill(0);for(const v of clean){const b=Math.min(bins-1,Math.floor((v-min)/(max-min)*bins));counts[b]++;}const maxC=Math.max(...counts,1),bw=(w-40)/bins;histCtx.strokeStyle='rgba(58,75,118,.9)';histCtx.lineWidth=2;histCtx.strokeRect(30,20,w-40,h-40);for(let i=0;i<bins;i++){const bh=(counts[i]/maxC)*(h-56);histCtx.fillStyle='rgba(62,220,255,.75)';histCtx.fillRect(32+i*bw,h-22-bh,bw-3,bh);}}
-function updateMetrics(){const i=Math.min(state.selectedIndex,Math.max(0,state.points.length-1));state.selectedIndex=i;const d=neighborCache[i]||[];const k=Math.min(state.k,d.length);el.kValue.textContent=String(k);el.nPointsValue.textContent=String(state.nPoints);el.noiseValue.textContent=state.noise.toFixed(3);el.outlierValue.textContent=state.outlierFrac.toFixed(2);const local=localMle(d,k),global=datasetAvg(k),agg=kRangeAverage();el.mle.textContent=Number.isFinite(local)?local.toFixed(4):'—';el.gmle.textContent=Number.isFinite(global)?global.toFixed(4):'—';el.agg.textContent=Number.isFinite(agg)?agg.toFixed(4):'—';el.status.textContent=`Selected #${i+1} • ${state.manifoldType} • noise=${state.noise.toFixed(3)} • outliers=${state.outlierFrac.toFixed(2)}`;el.termsBody.innerHTML='';if(k>=3){const Tk=d[k-1];for(let j=0;j<k-1;j++){const tr=document.createElement('tr');tr.innerHTML=`<td>${j+1}</td><td>${d[j].toFixed(4)}</td><td>${Math.log(Tk/d[j]).toFixed(6)}</td>`;el.termsBody.appendChild(tr);}}drawHistogram(neighborCache.map(v=>localMle(v,k)));}
-function drawHeroFrame(){const w=el.heroCanvas.width,h=el.heroCanvas.height;heroCtx.clearRect(0,0,w,h);heroCtx.fillStyle='#050812';heroCtx.fillRect(0,0,w,h);const line=state.manifoldType==='line';for(let i=0;i<state.points.length;i++){const p=state.points[i];let x=p.x*w,y=p.y*h;if(!prefersReducedMotion){const phase=(i*0.08+state.t*0.9);y+=Math.sin(phase)*(line?1.4:1.1);x+=Math.cos(phase*0.7)*0.8;}heroCtx.fillStyle='rgba(62,220,255,0.72)';heroCtx.beginPath();heroCtx.arc(x,y,2.5,0,Math.PI*2);heroCtx.fill();}const p=state.points[state.selectedIndex];if(p){const x=p.x*w,y=p.y*h;heroCtx.strokeStyle='rgba(142,123,255,.85)';heroCtx.lineWidth=3.2;heroCtx.beginPath();heroCtx.arc(x,y,15,0,Math.PI*2);heroCtx.stroke();heroCtx.fillStyle='rgba(255,184,77,1)';heroCtx.beginPath();heroCtx.arc(x,y,4.2,0,Math.PI*2);heroCtx.fill();}if(!prefersReducedMotion){state.t+=0.016;requestAnimationFrame(drawHeroFrame);}}
-function regenerate(){state.points=genPoints();state.selectedIndex=0;rebuildCache();updateMetrics();drawMain();if(prefersReducedMotion)drawHeroFrame();}
-function pickNearest(clientX,clientY){const r=el.simCanvas.getBoundingClientRect();const x=((clientX-r.left)/r.width)*el.simCanvas.width,y=((clientY-r.top)/r.height)*el.simCanvas.height;let best=0,bestD=Infinity;for(let i=0;i<state.points.length;i++){const p=state.points[i],d=Math.hypot(p.x*el.simCanvas.width-x,p.y*el.simCanvas.height-y);if(d<bestD){bestD=d;best=i;}}state.selectedIndex=best;updateMetrics();drawMain();}
-el.simCanvas.addEventListener('click',e=>pickNearest(e.clientX,e.clientY));el.simCanvas.addEventListener('keydown',e=>{if(e.key==='ArrowRight'||e.key==='ArrowDown'){state.selectedIndex=(state.selectedIndex+1)%state.points.length;updateMetrics();drawMain();e.preventDefault();}if(e.key==='ArrowLeft'||e.key==='ArrowUp'){state.selectedIndex=(state.selectedIndex-1+state.points.length)%state.points.length;updateMetrics();drawMain();e.preventDefault();}});el.manifoldType.addEventListener('change',()=>{state.manifoldType=el.manifoldType.value;regenerate();});el.nPoints.addEventListener('input',()=>{state.nPoints=Number(el.nPoints.value);regenerate();});el.kRange.addEventListener('input',()=>{state.k=Number(el.kRange.value);updateMetrics();drawMain();});el.noise.addEventListener('input',()=>{state.noise=Number(el.noise.value);regenerate();});el.outlier.addEventListener('input',()=>{state.outlierFrac=Number(el.outlier.value);regenerate();});el.regen.addEventListener('click',regenerate);
-regenerate(); if(!prefersReducedMotion) requestAnimationFrame(drawHeroFrame);
-let b=document.querySelector('#menu-trigger'),m=document.querySelector('.menu');b.addEventListener('click',()=>m.classList.toggle('hidden'));document.body.addEventListener('click',e=>{if(!b.contains(e.target))m.classList.add('hidden')});
+<header class="header"><nav class="nav"><div class="logo"><a href="https://ldomenichelli.github.io/" accesskey="h" title="lucia's notes (Alt + H)">lucia's notes</a><div class="logo-switches"><ul class="lang-switch"><li>|</li></ul></div></div><button id="menu-trigger" aria-haspopup="menu" aria-label="Menu Button"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentcolor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-menu"><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="18" x2="21" y2="18"/></svg></button><ul class="menu hidden"><li><a href="https://ldomenichelli.github.io/about/" title="about"><span>about</span></a></li><li><a href="https://ldomenichelli.github.io/posts/" title="notes"><span>notes</span></a></li><li><a href="https://ldomenichelli.github.io/projects/" title="projects"><span>projects</span></a></li><li><a href="https://ldomenichelli.github.io/random/" title="hobbies"><span>hobbies</span></a></li></ul></nav></header>
+<main class="main">
+  <article class="post-single cinematic-wrap">
+    <header class="post-header">
+      <div class="hero">
+        <span class="badge">Intrinsic Dimensionality · Levina–Bickel MLE</span>
+        <h1 class="post-title">Estimating manifold dimension from local distance ratios</h1>
+        <p class="subtle">All estimator math below is shown in LaTeX, and the values are computed from the currently displayed neighborhood.</p>
+      </div>
+    </header>
+    <div class="post-content">
+      <div class="layout">
+        <section class="panel" aria-labelledby="what-is-id">
+          <h2 id="what-is-id">Local estimator</h2>
+          <div class="formula">$$\hat{m}_k(x)=\left[\frac{1}{k-1}\sum_{j=1}^{k-1}\log\frac{T_k(x)}{T_j(x)}\right]^{-1}$$</div>
+          <p>Here $T_j(x)$ is the $j$-th nearest-neighbor distance from $x$. The point inspector computes every term in the sum and updates $\hat{m}_k(x)$ live.</p>
+          <div class="formula">$$\hat{m}_{\text{global}}(k)=\frac{1}{N}\sum_{i=1}^{N}\hat{m}_k(x_i)$$</div>
+          <p>The aggregate panel estimates a dataset-level dimension, and reports an interquartile spread to show instability.</p>
+        </section>
+        <aside class="panel" aria-labelledby="failure-modes">
+          <h2 id="failure-modes">Failure-mode controls</h2>
+          <p class="subtle">Use sliders to stress the assumptions behind local Poisson-like neighbor behavior.</p>
+          <ul>
+            <li><strong>Boundary clipping:</strong> clips point coordinates to $[\beta,1-\beta]^2$, increasing boundary bias.</li>
+            <li><strong>Outliers:</strong> replaces a fraction of points with uniform noise in the ambient square.</li>
+            <li><strong>Noise:</strong> adds isotropic Gaussian perturbations.</li>
+          </ul>
+          <p class="warning">Interpret estimates as local summaries, not a single “true” number across all scales.</p>
+        </aside>
+      </div>
+
+      <section class="panel" aria-labelledby="m3-title" style="margin-top:16px;">
+        <h2 id="m3-title">Milestone 3 · Local + aggregate views</h2>
+        <div class="controls" aria-label="Generator controls">
+          <div class="control"><label for="manifoldType">Manifold type</label><select id="manifoldType"><option value="line">Line (1D)</option><option value="circle">Circle (1D)</option><option value="plane">Plane (2D)</option></select></div>
+          <div class="control"><label for="sampleSize">Sample size: <span id="sampleSizeValue">180</span></label><input id="sampleSize" type="range" min="80" max="480" step="20" value="180"></div>
+          <div class="control"><label for="kNeighbors">$k$: <span id="kNeighborsValue">12</span></label><input id="kNeighbors" type="range" min="3" max="48" step="1" value="12"></div>
+          <div class="control"><label for="noise">Noise $\sigma$: <span id="noiseValue">0.020</span></label><input id="noise" type="range" min="0" max="0.12" step="0.005" value="0.02"></div>
+          <div class="control"><label for="boundary">Boundary clip $\beta$: <span id="boundaryValue">0.000</span></label><input id="boundary" type="range" min="0" max="0.18" step="0.01" value="0"></div>
+          <div class="control"><label for="outliers">Outlier fraction: <span id="outlierValue">0.00</span></label><input id="outliers" type="range" min="0" max="0.40" step="0.01" value="0"></div>
+          <div class="control"><button id="regenerate" type="button">Regenerate sample</button></div>
+        </div>
+
+        <div class="demo-layout">
+          <div>
+            <canvas id="manifoldCanvas" width="700" height="500" tabindex="0" aria-label="Toy manifold points and selected neighborhood"></canvas>
+            <p class="subtle">Click to inspect a point. Keyboard: Arrow keys move selection; Home/End jump to first/last point.</p>
+          </div>
+          <div>
+            <div class="metrics">
+              <div class="metric"><span class="k">Selected point</span><span id="selectedLabel" class="v">#1</span></div>
+              <div class="metric"><span class="k">Local $\hat{m}_k(x)$</span><span id="localMleValue" class="v">—</span></div>
+              <div class="metric"><span class="k">$T_k(x)$</span><span id="tkValue" class="v">—</span></div>
+              <div class="metric"><span class="k">Global mean</span><span id="globalMean" class="v">—</span></div>
+              <div class="metric"><span class="k">Global median</span><span id="globalMedian" class="v">—</span></div>
+              <div class="metric"><span class="k">IQR</span><span id="globalIqr" class="v">—</span></div>
+            </div>
+            <div class="terms" style="margin-top:10px;"><table><thead><tr><th>$j$</th><th>$T_j(x)$</th><th>$\log(T_k/T_j)$</th></tr></thead><tbody id="termsBody"></tbody></table></div>
+          </div>
+        </div>
+
+        <div class="aggregate-layout">
+          <div class="hist-wrap">
+            <h3 style="margin:.1rem 0 .4rem;">Aggregate estimate distribution</h3>
+            <canvas id="histCanvas" width="600" height="260" aria-label="Histogram of local intrinsic-dimension estimates"></canvas>
+          </div>
+          <div class="hist-wrap">
+            <h3 style="margin:.1rem 0 .4rem;">Live status</h3>
+            <p id="statusText" aria-live="polite" class="subtle">Ready.</p>
+            <div class="formula">$$\text{IQR}=Q_{0.75}(\hat{m}_k)-Q_{0.25}(\hat{m}_k)$$</div>
+            <p class="subtle">Large IQR values indicate unstable local scaling or mixed regimes.</p>
+          </div>
+        </div>
+      </section>
+    </div>
+  </article>
+</main>
+<script type="module">
+  import { localMleFromSortedDistances } from '/assets/js/id-estimator.js';
+
+  // Minimal app state: one object, no hidden globals.
+  const state = { manifoldType: 'line', sampleSize: 180, k: 12, noise: 0.02, boundary: 0, outliers: 0, points: [], neighbors: [], selectedIndex: 0 };
+
+  const el = {
+    menuTrigger: document.querySelector('#menu-trigger'), menu: document.querySelector('.menu'),
+    manifoldType: document.querySelector('#manifoldType'), sampleSize: document.querySelector('#sampleSize'), sampleSizeValue: document.querySelector('#sampleSizeValue'),
+    kNeighbors: document.querySelector('#kNeighbors'), kNeighborsValue: document.querySelector('#kNeighborsValue'), noise: document.querySelector('#noise'), noiseValue: document.querySelector('#noiseValue'),
+    boundary: document.querySelector('#boundary'), boundaryValue: document.querySelector('#boundaryValue'), outliers: document.querySelector('#outliers'), outlierValue: document.querySelector('#outlierValue'), regenerate: document.querySelector('#regenerate'),
+    canvas: document.querySelector('#manifoldCanvas'), histCanvas: document.querySelector('#histCanvas'), termsBody: document.querySelector('#termsBody'),
+    selectedLabel: document.querySelector('#selectedLabel'), localMleValue: document.querySelector('#localMleValue'), tkValue: document.querySelector('#tkValue'),
+    globalMean: document.querySelector('#globalMean'), globalMedian: document.querySelector('#globalMedian'), globalIqr: document.querySelector('#globalIqr'), statusText: document.querySelector('#statusText')
+  };
+  const ctx = el.canvas.getContext('2d');
+  const histCtx = el.histCanvas.getContext('2d');
+
+  const randn = () => { const u = Math.max(1e-12, Math.random()); const v = Math.random(); return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v); };
+
+  function clamp01(v, margin = 0) { return Math.min(1 - margin, Math.max(margin, v)); }
+
+  function sortedNeighborsFor(i, pts) {
+    const p = pts[i];
+    const arr = [];
+    for (let j = 0; j < pts.length; j += 1) {
+      if (i === j) continue;
+      arr.push({ j, d: Math.hypot(p.x - pts[j].x, p.y - pts[j].y) });
+    }
+    arr.sort((a, b) => a.d - b.d);
+    return arr;
+  }
+
+  function makeBasePoint(i, n) {
+    const t = i / Math.max(1, n - 1);
+    if (state.manifoldType === 'line') return { x: 0.12 + 0.76 * t, y: 0.5 };
+    if (state.manifoldType === 'circle') { const a = 2 * Math.PI * t; return { x: 0.5 + 0.30 * Math.cos(a), y: 0.5 + 0.30 * Math.sin(a) }; }
+    return { x: 0.1 + 0.8 * Math.random(), y: 0.1 + 0.8 * Math.random() };
+  }
+
+  function rebuildDataset() {
+    const pts = [];
+    for (let i = 0; i < state.sampleSize; i += 1) {
+      let p = makeBasePoint(i, state.sampleSize);
+      p = { x: p.x + randn() * state.noise, y: p.y + randn() * state.noise };
+      p = { x: clamp01(p.x, state.boundary), y: clamp01(p.y, state.boundary) };
+      if (Math.random() < state.outliers) p = { x: 0.02 + 0.96 * Math.random(), y: 0.02 + 0.96 * Math.random() };
+      pts.push(p);
+    }
+    state.points = pts;
+    state.neighbors = pts.map((_, i) => sortedNeighborsFor(i, pts));
+    state.selectedIndex = Math.min(state.selectedIndex, Math.max(0, pts.length - 1));
+    syncControls();
+    drawMain();
+    refreshAllMetrics();
+  }
+
+  function syncControls() {
+    el.sampleSizeValue.textContent = String(state.sampleSize);
+    el.kNeighborsValue.textContent = String(state.k);
+    el.noiseValue.textContent = state.noise.toFixed(3);
+    el.boundaryValue.textContent = state.boundary.toFixed(3);
+    el.outlierValue.textContent = state.outliers.toFixed(2);
+  }
+
+  function drawMain() {
+    const w = el.canvas.width; const h = el.canvas.height;
+    ctx.clearRect(0, 0, w, h);
+    ctx.fillStyle = '#080d18'; ctx.fillRect(0, 0, w, h);
+    const idx = state.selectedIndex;
+    const p = state.points[idx];
+    if (!p) return;
+    const k = Math.min(state.k, state.neighbors[idx].length);
+
+    ctx.fillStyle = 'rgba(88,214,255,0.9)';
+    for (const q of state.points) { ctx.beginPath(); ctx.arc(q.x * w, q.y * h, 2.8, 0, Math.PI * 2); ctx.fill(); }
+
+    for (let i = 0; i < k; i += 1) {
+      const r = state.neighbors[idx][i].d * Math.min(w, h);
+      ctx.strokeStyle = i === k - 1 ? 'rgba(255,191,102,0.9)' : 'rgba(155,140,255,0.58)';
+      ctx.lineWidth = i === k - 1 ? 2.8 : 1.5;
+      ctx.beginPath(); ctx.arc(p.x * w, p.y * h, r, 0, Math.PI * 2); ctx.stroke();
+    }
+
+    for (let i = 0; i < k; i += 1) {
+      const q = state.points[state.neighbors[idx][i].j];
+      ctx.fillStyle = 'rgba(155,140,255,1)'; ctx.beginPath(); ctx.arc(q.x * w, q.y * h, 4, 0, Math.PI * 2); ctx.fill();
+    }
+
+    ctx.fillStyle = 'rgba(255,191,102,1)'; ctx.beginPath(); ctx.arc(p.x * w, p.y * h, 5.2, 0, Math.PI * 2); ctx.fill();
+  }
+
+  function summarize(values) {
+    const v = values.filter(Number.isFinite).sort((a, b) => a - b);
+    if (!v.length) return { mean: NaN, median: NaN, iqr: NaN, arr: [] };
+    const q = (p) => v[Math.floor((v.length - 1) * p)];
+    const mean = v.reduce((a, b) => a + b, 0) / v.length;
+    return { mean, median: q(0.5), iqr: q(0.75) - q(0.25), arr: v };
+  }
+
+  function drawHistogram(vals) {
+    const w = el.histCanvas.width; const h = el.histCanvas.height;
+    histCtx.clearRect(0, 0, w, h);
+    histCtx.fillStyle = '#080d18'; histCtx.fillRect(0, 0, w, h);
+    const clean = vals.filter(Number.isFinite);
+    if (!clean.length) return;
+    const min = Math.max(0, Math.min(...clean));
+    const max = Math.max(...clean, min + 1e-6);
+    const bins = 16;
+    const counts = new Array(bins).fill(0);
+    for (const x of clean) {
+      const bi = Math.min(bins - 1, Math.floor(((x - min) / (max - min)) * bins));
+      counts[bi] += 1;
+    }
+    const maxC = Math.max(...counts, 1);
+    const bw = (w - 46) / bins;
+    histCtx.strokeStyle = 'rgba(61,84,122,0.9)'; histCtx.strokeRect(30, 16, w - 44, h - 34);
+    for (let i = 0; i < bins; i += 1) {
+      const barH = (counts[i] / maxC) * (h - 50);
+      histCtx.fillStyle = 'rgba(88,214,255,0.75)';
+      histCtx.fillRect(32 + i * bw, h - 20 - barH, bw - 2, barH);
+    }
+  }
+
+  function refreshAllMetrics() {
+    const idx = state.selectedIndex;
+    const nei = state.neighbors[idx] || [];
+    const distances = nei.map((x) => x.d);
+    const k = Math.min(state.k, distances.length);
+    const local = localMleFromSortedDistances(distances, k);
+
+    el.selectedLabel.textContent = `#${idx + 1}`;
+    el.localMleValue.textContent = Number.isFinite(local) ? local.toFixed(4) : '—';
+    el.tkValue.textContent = k > 0 ? distances[k - 1].toFixed(4) : '—';
+
+    el.termsBody.innerHTML = '';
+    if (k >= 2) {
+      const Tk = distances[k - 1];
+      for (let j = 0; j < k - 1; j += 1) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${j + 1}</td><td>${distances[j].toFixed(5)}</td><td>${Math.log(Tk / distances[j]).toFixed(6)}</td>`;
+        el.termsBody.appendChild(tr);
+      }
+    }
+
+    const localVals = state.neighbors.map((arr) => localMleFromSortedDistances(arr.map((x) => x.d), k));
+    const summary = summarize(localVals);
+    el.globalMean.textContent = Number.isFinite(summary.mean) ? summary.mean.toFixed(4) : '—';
+    el.globalMedian.textContent = Number.isFinite(summary.median) ? summary.median.toFixed(4) : '—';
+    el.globalIqr.textContent = Number.isFinite(summary.iqr) ? summary.iqr.toFixed(4) : '—';
+
+    drawHistogram(localVals);
+    el.statusText.textContent = `n=${state.sampleSize}, manifold=${state.manifoldType}, k=${state.k}, noise=${state.noise.toFixed(3)}, boundary=${state.boundary.toFixed(3)}, outliers=${state.outliers.toFixed(2)}.`;
+  }
+
+  function pickPoint(clientX, clientY) {
+    const r = el.canvas.getBoundingClientRect();
+    const x = (clientX - r.left) / r.width;
+    const y = (clientY - r.top) / r.height;
+    let best = 0; let bestDist = Infinity;
+    for (let i = 0; i < state.points.length; i += 1) {
+      const d = Math.hypot(state.points[i].x - x, state.points[i].y - y);
+      if (d < bestDist) { bestDist = d; best = i; }
+    }
+    state.selectedIndex = best;
+    drawMain();
+    refreshAllMetrics();
+  }
+
+  el.manifoldType.addEventListener('change', () => { state.manifoldType = el.manifoldType.value; rebuildDataset(); });
+  el.sampleSize.addEventListener('input', () => { state.sampleSize = Number(el.sampleSize.value); rebuildDataset(); });
+  el.kNeighbors.addEventListener('input', () => { state.k = Number(el.kNeighbors.value); syncControls(); drawMain(); refreshAllMetrics(); });
+  el.noise.addEventListener('input', () => { state.noise = Number(el.noise.value); rebuildDataset(); });
+  el.boundary.addEventListener('input', () => { state.boundary = Number(el.boundary.value); rebuildDataset(); });
+  el.outliers.addEventListener('input', () => { state.outliers = Number(el.outliers.value); rebuildDataset(); });
+  el.regenerate.addEventListener('click', rebuildDataset);
+
+  el.canvas.addEventListener('click', (e) => pickPoint(e.clientX, e.clientY));
+  el.canvas.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') state.selectedIndex = (state.selectedIndex + 1) % state.points.length;
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') state.selectedIndex = (state.selectedIndex - 1 + state.points.length) % state.points.length;
+    else if (e.key === 'Home') state.selectedIndex = 0;
+    else if (e.key === 'End') state.selectedIndex = state.points.length - 1;
+    else return;
+    e.preventDefault();
+    drawMain();
+    refreshAllMetrics();
+  });
+
+  el.menuTrigger.addEventListener('click', () => el.menu.classList.toggle('hidden'));
+  document.body.addEventListener('click', (e) => { if (!el.menuTrigger.contains(e.target)) el.menu.classList.add('hidden'); });
+
+  rebuildDataset();
 </script>
 </body>
 </html>

--- a/tests/id-estimator.test.mjs
+++ b/tests/id-estimator.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { datasetMle } from '../assets/js/id-estimator.js';
+
+function linePoints(n = 500, noise = 0.002) {
+  const pts = [];
+  for (let i = 0; i < n; i += 1) {
+    const t = i / (n - 1);
+    pts.push({ x: 0.1 + 0.8 * t + (Math.random() - 0.5) * noise, y: 0.5 + (Math.random() - 0.5) * noise });
+  }
+  return pts;
+}
+
+function planePoints(n = 500) {
+  const pts = [];
+  for (let i = 0; i < n; i += 1) {
+    pts.push({ x: 0.1 + 0.8 * Math.random(), y: 0.1 + 0.8 * Math.random() });
+  }
+  return pts;
+}
+
+test('Levina–Bickel dataset MLE is close to 1 for synthetic line data', () => {
+  const id = datasetMle(linePoints(550, 0.003), 12);
+  assert.ok(Number.isFinite(id));
+  assert.ok(id > 0.75 && id < 1.35, `expected near 1, got ${id}`);
+});
+
+test('Levina–Bickel dataset MLE is close to 2 for synthetic plane data', () => {
+  const id = datasetMle(planePoints(700), 16);
+  assert.ok(Number.isFinite(id));
+  assert.ok(id > 1.55 && id < 2.55, `expected near 2, got ${id}`);
+});


### PR DESCRIPTION
### Motivation
- Provide a small, dependency-free implementation of the Levina–Bickel k-NN MLE and an interactive explainer to visualize local and aggregate intrinsic-dimension estimates.
- Make the estimator reusable from both the demo and automated Node tests.

### Description
- Add estimator utilities in `assets/js/id-estimator.js` (and a public copy in `public/assets/js/id-estimator.js`) exporting `localMleFromSortedDistances`, `pairwiseSortedDistances`, and `datasetMle` for programmatic use.
- Add a full interactive demo page at `projects/intrinsic-dimensionality/index.html` (and the `public` counterpart) that implements a toy manifold generator, canvas visualizer, controls, and imports `localMleFromSortedDistances` as a module to compute live local and aggregate metrics.
- Update `projects/index.html` (and `public/projects/index.html`) to link to the new Intrinsic Dimensionality demo.
- Add unit tests in `tests/id-estimator.test.mjs` that validate the `datasetMle` result on synthetic 1D line data and 2D plane data.

### Testing
- Ran the Node test suite for `tests/id-estimator.test.mjs` using `node:test` to exercise `datasetMle` on synthetic datasets.
- The two tests (expecting ~1 for line data and ~2 for plane data) executed and passed.
- The estimator functions are exercised by the demo pages via an ES module import and by the automated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b324c2344483219904dad907773973)