### PR TITLE
Projects page: apply dark styling and simplify project listing

### DIFF
--- a/projects/index.html
+++ b/projects/index.html
@@ -40,14 +40,27 @@
 <h1 class="post-title">Projects</h1>
 </header>
 <div class="post-content">
-<p>A few things I'm working on:</p>
-<ul>
-<li><strong><a href="/projects/intrinsic-dimensionality/">Intrinsic Dimensionality (Levina–Bickel MLE demo)</a></strong> – Interactive explainer for local neighbor-based intrinsic dimension estimation.</li>
-</ul>
-<p>
-<img src="/random/tea/img/tea.jpeg" alt="Cute teacup photo for the Intrinsic Dimensionality project" style="max-width:320px;width:100%;border-radius:14px;display:block;margin-top:12px;">
-<em>A cute image for this project ☕✨</em>
-</p>
+<style>
+  body.page {
+    background: #000;
+    color: #fff;
+  }
+  .post-content p, .post-content li, .post-content a, .post-title {
+    color: #fff;
+  }
+  .project-button {
+    display: inline-block;
+    margin-top: 12px;
+    padding: 12px 22px;
+    border-radius: 8px;
+    border: 1px solid #fff;
+    background: #111;
+    color: #fff;
+    text-decoration: none;
+    font-weight: 600;
+  }
+</style>
+<p><a class="project-button" href="/projects/intrinsic-dimensionality/">Intriisic Dimnsionality</a></p>
 </div>
 </article>
 </main>

--- a/public/projects/index.html
+++ b/public/projects/index.html
@@ -40,14 +40,27 @@
 <h1 class="post-title">Projects</h1>
 </header>
 <div class="post-content">
-<p>A few things I'm working on:</p>
-<ul>
-<li><strong><a href="/projects/intrinsic-dimensionality/">Intrinsic Dimensionality (Levina–Bickel MLE demo)</a></strong> – Interactive explainer for local neighbor-based intrinsic dimension estimation.</li>
-</ul>
-<p>
-<img src="/random/tea/img/tea.jpeg" alt="Cute teacup photo for the Intrinsic Dimensionality project" style="max-width:320px;width:100%;border-radius:14px;display:block;margin-top:12px;">
-<em>A cute image for this project ☕✨</em>
-</p>
+<style>
+  body.page {
+    background: #000;
+    color: #fff;
+  }
+  .post-content p, .post-content li, .post-content a, .post-title {
+    color: #fff;
+  }
+  .project-button {
+    display: inline-block;
+    margin-top: 12px;
+    padding: 12px 22px;
+    border-radius: 8px;
+    border: 1px solid #fff;
+    background: #111;
+    color: #fff;
+    text-decoration: none;
+    font-weight: 600;
+  }
+</style>
+<p><a class="project-button" href="/projects/intrinsic-dimensionality/">Intriisic Dimnsionality</a></p>
 </div>
 </article>
 </main>


### PR DESCRIPTION
### Motivation
- Restyle the Projects page to use a dark theme and make the project entry more prominent. 
- Remove the previous list and illustrative image to simplify the page and provide a single call-to-action.

### Description
- Updated `projects/index.html` and `public/projects/index.html` to remove the old list and image and replace them with an inline stylesheet that applies a dark theme (`background: #000` / `color: #fff`).
- Added CSS rules for `.post-content` elements and a new `.project-button` class to present a single prominent link to the intrinsic dimensionality project.
- Replaced the previous list content with a single button-style link (`<a class="project-button" href="/projects/intrinsic-dimensionality/">Intriisic Dimnsionality</a>`), noting the link text contains typos as introduced in the change.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b32a7c105c832197c80a0153ae19e3)