### PR TITLE
Add Adugo playable game: engine, AI, UI, styles, and unit tests

### DIFF
--- a/assets/css/adugo.css
+++ b/assets/css/adugo.css
@@ -1,0 +1,320 @@
+:root {
+  --adugo-bg: #0f1116;
+  --adugo-panel: #171a23;
+  --adugo-panel-alt: #1d2230;
+  --adugo-border: #2f374d;
+  --adugo-text: #e9edf7;
+  --adugo-muted: #b3bfd9;
+  --adugo-accent: #83a4ff;
+  --adugo-accent-soft: rgba(131, 164, 255, 0.18);
+  --adugo-danger: #ff7b7b;
+  --adugo-jaguar: #e8b43f;
+  --adugo-dog: #d7dde8;
+}
+
+.adugo-shell {
+  margin-top: 0.75rem;
+  border: 1px solid var(--adugo-border);
+  border-radius: 18px;
+  background: linear-gradient(175deg, #121521 0%, #0f1116 100%);
+  color: var(--adugo-text);
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.33);
+  overflow: hidden;
+}
+
+.adugo-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 1.1rem;
+  border-bottom: 1px solid var(--adugo-border);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0));
+}
+
+.adugo-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.02em;
+}
+
+.adugo-subtitle {
+  margin: 0;
+  color: var(--adugo-muted);
+  font-size: 0.9rem;
+}
+
+.adugo-win-banner {
+  margin: 0.75rem 1rem 0;
+  padding: 0.55rem 0.8rem;
+  border-radius: 10px;
+  border: 1px solid rgba(232, 180, 63, 0.5);
+  background: rgba(232, 180, 63, 0.12);
+  color: #ffe8ae;
+  font-weight: 600;
+}
+
+.adugo-main {
+  display: grid;
+  grid-template-columns: 1.5fr minmax(260px, 340px);
+  gap: 0.9rem;
+  padding: 0.9rem;
+}
+
+.adugo-board-wrap {
+  background: var(--adugo-panel);
+  border: 1px solid var(--adugo-border);
+  border-radius: 16px;
+  padding: 0.9rem;
+}
+
+.adugo-board {
+  position: relative;
+  aspect-ratio: 1 / 1;
+  width: min(100%, 690px);
+  margin: 0 auto;
+  background: radial-gradient(circle at top left, #2d3244 0%, #1f2432 35%, #171a23 100%);
+  border-radius: 14px;
+  border: 1px solid #3a4562;
+  overflow: hidden;
+}
+
+.adugo-lines {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.adugo-line {
+  position: absolute;
+  transform-origin: 0 0;
+  height: 2px;
+  background: linear-gradient(90deg, #4f5873, #5f6a8a);
+  opacity: 0.7;
+}
+
+.adugo-node {
+  position: absolute;
+  width: clamp(34px, 6.4vw, 54px);
+  height: clamp(34px, 6.4vw, 54px);
+  margin-left: calc(clamp(34px, 6.4vw, 54px) * -0.5);
+  margin-top: calc(clamp(34px, 6.4vw, 54px) * -0.5);
+  border-radius: 999px;
+  border: 2px solid #8fa0cc33;
+  background: #151928;
+  z-index: 2;
+  cursor: pointer;
+  transition: transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease;
+}
+
+.adugo-node:hover,
+.adugo-node:focus-visible {
+  transform: translateY(-1px);
+  border-color: var(--adugo-accent);
+  box-shadow: 0 0 0 3px var(--adugo-accent-soft);
+  outline: none;
+}
+
+.adugo-node.is-selected {
+  border-color: #8ec5ff;
+  box-shadow: 0 0 0 4px rgba(142, 197, 255, 0.2);
+}
+
+.adugo-node.is-legal::after {
+  content: '';
+  position: absolute;
+  inset: 8px;
+  border-radius: 50%;
+  background: rgba(131, 164, 255, 0.5);
+}
+
+.adugo-node.is-chain::after {
+  background: rgba(255, 123, 123, 0.75);
+}
+
+.piece {
+  position: absolute;
+  inset: 5px;
+  border-radius: 50%;
+  z-index: 3;
+}
+
+.piece.jaguar {
+  background: radial-gradient(circle at 30% 26%, #ffde8c 0%, #e8b43f 62%, #9e6f00 100%);
+  box-shadow: inset 0 -3px 8px rgba(63, 38, 0, 0.45);
+}
+
+.piece.dog {
+  background: radial-gradient(circle at 30% 26%, #f6f8fd 0%, #d7dde8 60%, #8a95ad 100%);
+  box-shadow: inset 0 -2px 8px rgba(30, 40, 65, 0.35);
+}
+
+.adugo-side {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.adugo-card {
+  background: var(--adugo-panel-alt);
+  border: 1px solid var(--adugo-border);
+  border-radius: 12px;
+  padding: 0.75rem;
+}
+
+.adugo-grid2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
+.adugo-field {
+  display: grid;
+  gap: 0.35rem;
+  text-align: left;
+}
+
+.adugo-field label,
+.adugo-label {
+  font-size: 0.82rem;
+  color: var(--adugo-muted);
+}
+
+.adugo-select,
+.adugo-button {
+  font: inherit;
+  color: var(--adugo-text);
+  background: #111624;
+  border: 1px solid #34405d;
+  border-radius: 10px;
+  padding: 0.42rem 0.55rem;
+}
+
+.adugo-button {
+  cursor: pointer;
+}
+
+.adugo-button:hover,
+.adugo-button:focus-visible,
+.adugo-select:focus-visible {
+  border-color: var(--adugo-accent);
+  box-shadow: 0 0 0 3px var(--adugo-accent-soft);
+  outline: none;
+}
+
+.adugo-button[disabled] {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.adugo-stat {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px dashed #3b4663;
+  padding: 0.35rem 0;
+  font-size: 0.93rem;
+}
+
+.adugo-stat:last-child {
+  border-bottom: 0;
+}
+
+.adugo-status {
+  margin: 0.3rem 0 0;
+  color: #d5ddf2;
+  font-size: 0.9rem;
+}
+
+.adugo-thinking {
+  margin: 0.4rem 0 0;
+  font-size: 0.85rem;
+  color: #9eb4ff;
+}
+
+.adugo-history {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 170px;
+  overflow: auto;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.adugo-history-item {
+  font-size: 0.84rem;
+  color: #d7ddf0;
+  background: #121826;
+  border: 1px solid #2f3850;
+  border-radius: 8px;
+  padding: 0.3rem 0.45rem;
+}
+
+.adugo-empty-history {
+  color: var(--adugo-muted);
+  font-size: 0.85rem;
+}
+
+.adugo-tabs {
+  margin-top: 0.7rem;
+  border-top: 1px solid var(--adugo-border);
+}
+
+.adugo-tab-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0.75rem 0 0;
+  list-style: none;
+}
+
+.adugo-tab {
+  border: 1px solid #36425f;
+  background: #13182a;
+  color: var(--adugo-muted);
+  border-radius: 999px;
+  padding: 0.33rem 0.7rem;
+  cursor: pointer;
+  font-size: 0.82rem;
+}
+
+.adugo-tab[aria-selected='true'] {
+  color: var(--adugo-text);
+  border-color: #6385e7;
+  background: #1a2340;
+}
+
+.adugo-tab-panel {
+  margin-top: 0.7rem;
+  background: var(--adugo-panel);
+  border: 1px solid var(--adugo-border);
+  border-radius: 12px;
+  padding: 0.75rem;
+  color: #d5deef;
+  font-size: 0.92rem;
+}
+
+.adugo-tab-panel p,
+.adugo-tab-panel ul,
+.adugo-tab-panel ol {
+  margin: 0.35rem 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .adugo-node,
+  .adugo-button,
+  .adugo-select {
+    transition: none;
+  }
+}
+
+@media (max-width: 980px) {
+  .adugo-main {
+    grid-template-columns: 1fr;
+  }
+
+  .adugo-board {
+    width: min(100%, 580px);
+  }
+}

--- a/assets/js/adugo-ai.js
+++ b/assets/js/adugo-ai.js
@@ -1,0 +1,166 @@
+import {
+  SIDES,
+  GAME_CONFIG,
+  applyMove,
+  getLegalMoves,
+  serializeState,
+  occupantAt,
+  ADJACENCY
+} from './adugo-engine.js';
+
+const DIFFICULTY = {
+  Easy: { depth: 2, randomness: 0.45 },
+  Medium: { depth: 4, randomness: 0.15 },
+  Hard: { depth: 5, randomness: 0 }
+};
+
+function opposite(side) {
+  return side === SIDES.JAGUAR ? SIDES.DOGS : SIDES.JAGUAR;
+}
+
+function jaguarMobility(state) {
+  return getLegalMoves({ ...state, turn: SIDES.JAGUAR, chainCaptureFrom: null }, SIDES.JAGUAR).length;
+}
+
+function dogNetPressure(state) {
+  const jaguarPos = state.jaguar;
+  let occupiedNeighbors = 0;
+  for (const n of ADJACENCY.get(jaguarPos)) {
+    if (occupantAt(state, n) === SIDES.DOGS) occupiedNeighbors += 1;
+  }
+  return occupiedNeighbors;
+}
+
+function immediateJaguarCaptures(state) {
+  return getLegalMoves({ ...state, turn: SIDES.JAGUAR, chainCaptureFrom: state.jaguar }, SIDES.JAGUAR)
+    .filter((m) => m.type === 'capture').length;
+}
+
+function centrality(index) {
+  const x = index % GAME_CONFIG.size;
+  const y = Math.floor(index / GAME_CONFIG.size);
+  return -Math.abs(2 - x) - Math.abs(2 - y);
+}
+
+function evaluate(state, side) {
+  if (state.winner === SIDES.JAGUAR) return side === SIDES.JAGUAR ? 100000 : -100000;
+  if (state.winner === SIDES.DOGS) return side === SIDES.DOGS ? 100000 : -100000;
+
+  const mobility = jaguarMobility(state);
+  const pressure = dogNetPressure(state);
+  const capturesSoon = immediateJaguarCaptures(state);
+
+  const jaguarScore =
+    state.capturedDogs * 230 +
+    mobility * 25 +
+    capturesSoon * 80 +
+    centrality(state.jaguar) * 10 -
+    pressure * 35;
+
+  const dogsScore =
+    pressure * 45 +
+    Math.max(0, 8 - mobility) * 32 -
+    state.capturedDogs * 210 -
+    capturesSoon * 95;
+
+  const evalFromJaguarPerspective = jaguarScore - dogsScore;
+  return side === SIDES.JAGUAR ? evalFromJaguarPerspective : -evalFromJaguarPerspective;
+}
+
+function orderMoves(state, moves) {
+  return [...moves].sort((a, b) => {
+    const av = (a.type === 'capture' ? 6 : 0) + centrality(a.to);
+    const bv = (b.type === 'capture' ? 6 : 0) + centrality(b.to);
+    return bv - av;
+  });
+}
+
+function minimax(state, depth, alpha, beta, maximizing, rootSide, table) {
+  const key = `${serializeState(state)}|${depth}|${maximizing}`;
+  if (table.has(key)) return table.get(key);
+
+  if (depth === 0 || state.winner) {
+    const score = evaluate(state, rootSide);
+    const result = { score, move: null };
+    table.set(key, result);
+    return result;
+  }
+
+  const moves = orderMoves(state, getLegalMoves(state, state.turn));
+  if (moves.length === 0) {
+    const score = evaluate(state, rootSide);
+    const result = { score, move: null };
+    table.set(key, result);
+    return result;
+  }
+
+  let bestMove = moves[0];
+
+  if (maximizing) {
+    let bestScore = -Infinity;
+    for (const move of moves) {
+      const child = applyMove(state, move);
+      const { score } = minimax(child, depth - 1, alpha, beta, child.turn === rootSide, rootSide, table);
+      if (score > bestScore) {
+        bestScore = score;
+        bestMove = move;
+      }
+      alpha = Math.max(alpha, bestScore);
+      if (beta <= alpha) break;
+    }
+    const result = { score: bestScore, move: bestMove };
+    table.set(key, result);
+    return result;
+  }
+
+  let bestScore = Infinity;
+  for (const move of moves) {
+    const child = applyMove(state, move);
+    const { score } = minimax(child, depth - 1, alpha, beta, child.turn === rootSide, rootSide, table);
+    if (score < bestScore) {
+      bestScore = score;
+      bestMove = move;
+    }
+    beta = Math.min(beta, bestScore);
+    if (beta <= alpha) break;
+  }
+  const result = { score: bestScore, move: bestMove };
+  table.set(key, result);
+  return result;
+}
+
+export function pickAIMove(state, side, difficulty = 'Medium') {
+  const settings = DIFFICULTY[difficulty] ?? DIFFICULTY.Medium;
+  const legal = getLegalMoves(state, side);
+  if (legal.length === 0) return null;
+
+  const table = new Map();
+  const maximizing = state.turn === side;
+  const { move } = minimax(state, settings.depth, -Infinity, Infinity, maximizing, side, table);
+
+  if (!move) return legal[0];
+
+  if (settings.randomness > 0 && legal.length > 1) {
+    const scored = legal.map((candidate) => {
+      const child = applyMove(state, candidate);
+      return { candidate, score: evaluate(child, side) };
+    }).sort((a, b) => b.score - a.score);
+
+    const topBucketSize = Math.max(1, Math.ceil(scored.length * settings.randomness));
+    const bucket = scored.slice(0, topBucketSize);
+    const randomPick = bucket[Math.floor(Math.random() * bucket.length)].candidate;
+    return randomPick;
+  }
+
+  return move;
+}
+
+export function thinkAndPickAIMove(state, side, difficulty = 'Medium', delayMs = 320) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(pickAIMove(state, side, difficulty));
+    }, delayMs);
+  });
+}
+
+export { opposite };

--- a/assets/js/adugo-engine.js
+++ b/assets/js/adugo-engine.js
@@ -1,0 +1,261 @@
+export const SIDES = Object.freeze({
+  JAGUAR: 'JAGUAR',
+  DOGS: 'DOGS'
+});
+
+export const GAME_CONFIG = Object.freeze({
+  size: 5,
+  // Centralized win condition. Existing page text states "capture all dogs".
+  jaguarCaptureTarget: 14,
+  initialJaguar: 12,
+  initialDogs: Object.freeze([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 15, 16])
+});
+
+const DIRECTIONS = Object.freeze([
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+  [1, 1],
+  [-1, -1],
+  [1, -1],
+  [-1, 1]
+]);
+
+export function indexToCoord(index) {
+  const x = index % GAME_CONFIG.size;
+  const y = Math.floor(index / GAME_CONFIG.size);
+  return { x, y };
+}
+
+export function coordToIndex(x, y) {
+  return y * GAME_CONFIG.size + x;
+}
+
+function inBounds(x, y) {
+  return x >= 0 && x < GAME_CONFIG.size && y >= 0 && y < GAME_CONFIG.size;
+}
+
+function hasDiagonal(x, y) {
+  return (x + y) % 2 === 0;
+}
+
+export function createAdjacency() {
+  const adjacency = new Map();
+  for (let i = 0; i < GAME_CONFIG.size * GAME_CONFIG.size; i += 1) {
+    const { x, y } = indexToCoord(i);
+    const neighbors = [];
+    for (const [dx, dy] of DIRECTIONS) {
+      const diagonal = Math.abs(dx) + Math.abs(dy) === 2;
+      if (diagonal && !hasDiagonal(x, y)) continue;
+      const nx = x + dx;
+      const ny = y + dy;
+      if (!inBounds(nx, ny)) continue;
+      if (diagonal && !hasDiagonal(nx, ny)) continue;
+      neighbors.push(coordToIndex(nx, ny));
+    }
+    adjacency.set(i, neighbors);
+  }
+  return adjacency;
+}
+
+export const ADJACENCY = createAdjacency();
+
+export function createInitialState(overrides = {}) {
+  const dogs = GAME_CONFIG.initialDogs.filter((pos) => pos !== GAME_CONFIG.initialJaguar);
+  return {
+    jaguar: GAME_CONFIG.initialJaguar,
+    dogs,
+    capturedDogs: 0,
+    turn: SIDES.JAGUAR,
+    winner: null,
+    moveNumber: 1,
+    chainCaptureFrom: null,
+    history: [],
+    ...overrides
+  };
+}
+
+export function cloneState(state) {
+  return {
+    ...state,
+    dogs: [...state.dogs],
+    history: state.history ? [...state.history] : []
+  };
+}
+
+export function occupantAt(state, index) {
+  if (state.jaguar === index) return SIDES.JAGUAR;
+  if (state.dogs.includes(index)) return SIDES.DOGS;
+  return null;
+}
+
+export function getStepDirection(from, to) {
+  const a = indexToCoord(from);
+  const b = indexToCoord(to);
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  if (Math.abs(dx) > 1 || Math.abs(dy) > 1) return null;
+  if (dx === 0 && dy === 0) return null;
+  const sx = Math.sign(dx);
+  const sy = Math.sign(dy);
+  const neighbor = coordToIndex(a.x + sx, a.y + sy);
+  return ADJACENCY.get(from).includes(neighbor) && neighbor === to ? { dx: sx, dy: sy } : null;
+}
+
+function jumpLanding(from, over) {
+  const f = indexToCoord(from);
+  const o = indexToCoord(over);
+  const dx = o.x - f.x;
+  const dy = o.y - f.y;
+  const lx = o.x + dx;
+  const ly = o.y + dy;
+  if (!inBounds(lx, ly)) return null;
+  const landing = coordToIndex(lx, ly);
+  if (!ADJACENCY.get(from).includes(over)) return null;
+  if (!ADJACENCY.get(over).includes(landing)) return null;
+  return landing;
+}
+
+export function getLegalSimpleMoves(state, side = state.turn) {
+  if (state.winner) return [];
+
+  if (side === SIDES.JAGUAR) {
+    const candidates = [];
+    for (const n of ADJACENCY.get(state.jaguar)) {
+      if (!occupantAt(state, n)) {
+        candidates.push({ from: state.jaguar, to: n, type: 'move', side });
+      }
+    }
+    return candidates;
+  }
+
+  const moves = [];
+  for (const from of state.dogs) {
+    for (const to of ADJACENCY.get(from)) {
+      if (!occupantAt(state, to)) {
+        moves.push({ from, to, type: 'move', side });
+      }
+    }
+  }
+  return moves;
+}
+
+export function getLegalJaguarCaptures(state, from = state.jaguar) {
+  const captures = [];
+  for (const neighbor of ADJACENCY.get(from)) {
+    if (occupantAt(state, neighbor) !== SIDES.DOGS) continue;
+    const landing = jumpLanding(from, neighbor);
+    if (landing == null) continue;
+    if (occupantAt(state, landing)) continue;
+    captures.push({
+      from,
+      to: landing,
+      over: neighbor,
+      type: 'capture',
+      side: SIDES.JAGUAR
+    });
+  }
+  return captures;
+}
+
+export function getLegalMoves(state, side = state.turn) {
+  if (state.winner) return [];
+
+  if (side === SIDES.JAGUAR) {
+    if (state.chainCaptureFrom != null) {
+      return getLegalJaguarCaptures(state, state.chainCaptureFrom);
+    }
+    return [...getLegalJaguarCaptures(state), ...getLegalSimpleMoves(state, SIDES.JAGUAR)];
+  }
+
+  return getLegalSimpleMoves(state, SIDES.DOGS);
+}
+
+function removeDog(dogs, idx) {
+  const next = dogs.filter((d) => d !== idx);
+  if (next.length === dogs.length) {
+    throw new Error(`Dog at ${idx} not found`);
+  }
+  return next;
+}
+
+export function detectWinner(state) {
+  if (state.capturedDogs >= GAME_CONFIG.jaguarCaptureTarget) {
+    return SIDES.JAGUAR;
+  }
+  const jaguarMoves = state.chainCaptureFrom != null
+    ? getLegalJaguarCaptures(state, state.chainCaptureFrom)
+    : getLegalMoves({ ...state, turn: SIDES.JAGUAR, chainCaptureFrom: null }, SIDES.JAGUAR);
+  if (jaguarMoves.length === 0) {
+    return SIDES.DOGS;
+  }
+  return null;
+}
+
+function makeHistoryEntry(move, actorSide, previousState) {
+  return {
+    move,
+    actorSide,
+    moveNumber: previousState.moveNumber,
+    capturedDogs: previousState.capturedDogs,
+    turnBefore: previousState.turn
+  };
+}
+
+export function applyMove(state, move) {
+  const legalMoves = getLegalMoves(state, state.turn);
+  const key = `${move.from}-${move.to}-${move.type}`;
+  const legal = legalMoves.find((m) => `${m.from}-${m.to}-${m.type}` === key && (m.over ?? -1) === (move.over ?? -1));
+  if (!legal) {
+    throw new Error('Illegal move');
+  }
+
+  const next = cloneState(state);
+  next.history.push(makeHistoryEntry(legal, state.turn, state));
+
+  if (state.turn === SIDES.JAGUAR) {
+    next.jaguar = legal.to;
+    if (legal.type === 'capture') {
+      next.dogs = removeDog(next.dogs, legal.over);
+      next.capturedDogs += 1;
+      const followUps = getLegalJaguarCaptures({ ...next, chainCaptureFrom: legal.to }, legal.to);
+      if (followUps.length > 0) {
+        next.turn = SIDES.JAGUAR;
+        next.chainCaptureFrom = legal.to;
+      } else {
+        next.turn = SIDES.DOGS;
+        next.chainCaptureFrom = null;
+        next.moveNumber += 1;
+      }
+    } else {
+      next.turn = SIDES.DOGS;
+      next.chainCaptureFrom = null;
+      next.moveNumber += 1;
+    }
+  } else {
+    next.dogs = next.dogs.map((d) => (d === legal.from ? legal.to : d));
+    next.turn = SIDES.JAGUAR;
+    next.chainCaptureFrom = null;
+    next.moveNumber += 1;
+  }
+
+  next.winner = detectWinner(next);
+  return next;
+}
+
+export function serializeState(state) {
+  return JSON.stringify({
+    jaguar: state.jaguar,
+    dogs: [...state.dogs].sort((a, b) => a - b),
+    capturedDogs: state.capturedDogs,
+    turn: state.turn,
+    winner: state.winner,
+    moveNumber: state.moveNumber,
+    chainCaptureFrom: state.chainCaptureFrom
+  });
+}
+
+export function isMoveLegal(state, move) {
+  return getLegalMoves(state).some((m) => m.from === move.from && m.to === move.to && m.type === move.type && (m.over ?? null) === (move.over ?? null));
+}

--- a/assets/js/adugo-page.js
+++ b/assets/js/adugo-page.js
@@ -1,0 +1,366 @@
+import {
+  SIDES,
+  GAME_CONFIG,
+  createInitialState,
+  applyMove,
+  getLegalMoves,
+  getLegalJaguarCaptures,
+  indexToCoord,
+  ADJACENCY
+} from './adugo-engine.js';
+import { thinkAndPickAIMove, opposite } from './adugo-ai.js';
+
+const MODE = {
+  HVH: 'HUMAN_VS_HUMAN',
+  HVC: 'HUMAN_VS_COMPUTER'
+};
+
+const state = {
+  game: createInitialState(),
+  selected: null,
+  mode: MODE.HVH,
+  humanSide: SIDES.JAGUAR,
+  difficulty: 'Medium',
+  isThinking: false,
+  snapshots: []
+};
+
+const boardEl = document.querySelector('[data-adugo-board]');
+const turnEl = document.querySelector('[data-turn]');
+const capturedEl = document.querySelector('[data-captured]');
+const objectiveEl = document.querySelector('[data-objective]');
+const statusEl = document.querySelector('[data-status]');
+const thinkingEl = document.querySelector('[data-thinking]');
+const historyEl = document.querySelector('[data-history]');
+const bannerEl = document.querySelector('[data-win-banner]');
+const modeEl = document.querySelector('[data-mode]');
+const sideEl = document.querySelector('[data-side]');
+const diffEl = document.querySelector('[data-difficulty]');
+const newGameEl = document.querySelector('[data-new-game]');
+const undoEl = document.querySelector('[data-undo]');
+
+function isHumanTurn() {
+  if (state.game.winner) return false;
+  if (state.mode === MODE.HVH) return true;
+  return state.game.turn === state.humanSide;
+}
+
+function canUndoPair() {
+  if (state.snapshots.length === 0) return false;
+  return true;
+}
+
+function pushSnapshot() {
+  state.snapshots.push(structuredClone(state.game));
+  if (state.snapshots.length > 200) state.snapshots.shift();
+}
+
+function popSnapshot() {
+  return state.snapshots.pop() ?? null;
+}
+
+function prettySide(side) {
+  return side === SIDES.JAGUAR ? 'Jaguar' : 'Dogs';
+}
+
+function buildBoard() {
+  boardEl.innerHTML = '';
+  for (let i = 0; i < GAME_CONFIG.size * GAME_CONFIG.size; i += 1) {
+    const node = document.createElement('button');
+    node.type = 'button';
+    node.className = 'adugo-node';
+    node.dataset.index = String(i);
+    node.setAttribute('aria-label', `Node ${i + 1}`);
+    boardEl.appendChild(node);
+  }
+
+  for (let i = 0; i < GAME_CONFIG.size * GAME_CONFIG.size; i += 1) {
+    const { x, y } = indexToCoord(i);
+    const left = `${(x / (GAME_CONFIG.size - 1)) * 100}%`;
+    const top = `${(y / (GAME_CONFIG.size - 1)) * 100}%`;
+    const node = boardEl.querySelector(`[data-index="${i}"]`);
+    node.style.left = left;
+    node.style.top = top;
+  }
+
+  const lineLayer = document.createElement('div');
+  lineLayer.className = 'adugo-lines';
+  boardEl.appendChild(lineLayer);
+
+  const drawn = new Set();
+  for (let i = 0; i < GAME_CONFIG.size * GAME_CONFIG.size; i += 1) {
+    const from = indexToCoord(i);
+    for (const n of ADJACENCY.get(i)) {
+      const key = [i, n].sort((a, b) => a - b).join('-');
+      if (drawn.has(key)) continue;
+      drawn.add(key);
+      const to = indexToCoord(n);
+      const line = document.createElement('span');
+      line.className = 'adugo-line';
+
+      const x1 = (from.x / (GAME_CONFIG.size - 1)) * 100;
+      const y1 = (from.y / (GAME_CONFIG.size - 1)) * 100;
+      const x2 = (to.x / (GAME_CONFIG.size - 1)) * 100;
+      const y2 = (to.y / (GAME_CONFIG.size - 1)) * 100;
+      const dx = x2 - x1;
+      const dy = y2 - y1;
+      const length = Math.sqrt(dx * dx + dy * dy);
+      const angle = (Math.atan2(dy, dx) * 180) / Math.PI;
+
+      line.style.left = `${x1}%`;
+      line.style.top = `${y1}%`;
+      line.style.width = `${length}%`;
+      line.style.transform = `rotate(${angle}deg)`;
+      lineLayer.appendChild(line);
+    }
+  }
+}
+
+function annotateHistory() {
+  historyEl.innerHTML = '';
+  if (!state.game.history.length) {
+    historyEl.innerHTML = '<li class="adugo-empty-history">No moves yet.</li>';
+    return;
+  }
+
+  const items = state.game.history.slice(-200).map((h, idx) => {
+    const li = document.createElement('li');
+    li.className = 'adugo-history-item';
+    const capture = h.move.type === 'capture' ? ' ×' : '';
+    li.textContent = `${idx + 1}. ${prettySide(h.actorSide)} ${h.move.from + 1}→${h.move.to + 1}${capture}`;
+    return li;
+  });
+
+  items.forEach((i) => historyEl.appendChild(i));
+  historyEl.scrollTop = historyEl.scrollHeight;
+}
+
+function currentObjectiveText() {
+  const needed = Math.max(0, GAME_CONFIG.jaguarCaptureTarget - state.game.capturedDogs);
+  return `Jaguar wins by capturing ${GAME_CONFIG.jaguarCaptureTarget} dogs. Remaining: ${needed}. Dogs win by trapping the jaguar.`;
+}
+
+function highlightLegalTargets() {
+  const nodes = boardEl.querySelectorAll('.adugo-node');
+  nodes.forEach((n) => n.classList.remove('is-legal', 'is-selected', 'is-jaguar', 'is-dog', 'is-chain'));
+
+  const moves = getLegalMoves(state.game, state.game.turn);
+  const selectedMoves = state.selected
+    ? moves.filter((m) => m.from === state.selected)
+    : [];
+
+  for (const node of nodes) {
+    const idx = Number(node.dataset.index);
+    if (idx === state.game.jaguar) {
+      node.classList.add('is-jaguar');
+      node.innerHTML = '<span class="piece jaguar" aria-hidden="true"></span>';
+    } else if (state.game.dogs.includes(idx)) {
+      node.classList.add('is-dog');
+      node.innerHTML = '<span class="piece dog" aria-hidden="true"></span>';
+    } else {
+      node.innerHTML = '';
+    }
+
+    if (state.selected === idx) {
+      node.classList.add('is-selected');
+    }
+
+    if (selectedMoves.some((m) => m.to === idx)) {
+      node.classList.add('is-legal');
+      if (selectedMoves.some((m) => m.type === 'capture' && m.to === idx)) {
+        node.classList.add('is-chain');
+      }
+    }
+  }
+}
+
+function updateStatusPanel() {
+  turnEl.textContent = prettySide(state.game.turn);
+  capturedEl.textContent = String(state.game.capturedDogs);
+  objectiveEl.textContent = currentObjectiveText();
+
+  if (state.game.winner) {
+    statusEl.textContent = `${prettySide(state.game.winner)} win!`;
+    bannerEl.hidden = false;
+    bannerEl.textContent = `${prettySide(state.game.winner)} win the game.`;
+  } else if (state.game.chainCaptureFrom != null) {
+    statusEl.textContent = 'Jaguar must continue the capture chain.';
+    bannerEl.hidden = true;
+  } else {
+    statusEl.textContent = `${prettySide(state.game.turn)} to move.`;
+    bannerEl.hidden = true;
+  }
+
+  thinkingEl.hidden = !(state.mode === MODE.HVC && state.isThinking);
+  undoEl.disabled = !canUndoPair();
+}
+
+function syncControls() {
+  modeEl.value = state.mode;
+  sideEl.value = state.humanSide;
+  diffEl.value = state.difficulty;
+  sideEl.disabled = state.mode === MODE.HVH;
+  diffEl.disabled = state.mode === MODE.HVH;
+}
+
+function render() {
+  syncControls();
+  highlightLegalTargets();
+  updateStatusPanel();
+  annotateHistory();
+}
+
+function selectNode(index) {
+  if (!isHumanTurn() || state.isThinking) return;
+
+  const occ = index === state.game.jaguar ? SIDES.JAGUAR : state.game.dogs.includes(index) ? SIDES.DOGS : null;
+  const moves = getLegalMoves(state.game, state.game.turn);
+
+  if (state.selected == null) {
+    if (occ === state.game.turn) {
+      state.selected = index;
+    }
+    render();
+    return;
+  }
+
+  if (state.selected === index) {
+    state.selected = null;
+    render();
+    return;
+  }
+
+  const candidate = moves.find((m) => m.from === state.selected && m.to === index);
+  if (candidate) {
+    executeMove(candidate);
+    return;
+  }
+
+  if (occ === state.game.turn) {
+    state.selected = index;
+  } else {
+    state.selected = null;
+  }
+  render();
+}
+
+async function maybeAIMove() {
+  if (state.mode !== MODE.HVC || state.game.winner) return;
+  const aiSide = opposite(state.humanSide);
+  if (state.game.turn !== aiSide) return;
+
+  state.isThinking = true;
+  state.selected = null;
+  render();
+
+  const move = await thinkAndPickAIMove(state.game, aiSide, state.difficulty);
+  state.isThinking = false;
+  if (move) {
+    executeMove(move, { triggerAI: false });
+  } else {
+    render();
+  }
+}
+
+function executeMove(move, opts = { triggerAI: true }) {
+  pushSnapshot();
+  state.game = applyMove(state.game, move);
+  if (state.game.chainCaptureFrom != null && state.game.turn === SIDES.JAGUAR) {
+    state.selected = state.game.jaguar;
+  } else {
+    state.selected = null;
+  }
+  render();
+  if (opts.triggerAI !== false) {
+    maybeAIMove();
+  }
+}
+
+function undoMove() {
+  if (!canUndoPair()) return;
+
+  if (state.mode === MODE.HVC) {
+    const aiSide = opposite(state.humanSide);
+    let popped = popSnapshot();
+    if (!popped) return;
+
+    state.game = popped;
+    if (state.game.turn === aiSide && state.snapshots.length > 0) {
+      state.game = popSnapshot() ?? state.game;
+    }
+  } else {
+    state.game = popSnapshot() ?? state.game;
+  }
+
+  state.selected = null;
+  state.isThinking = false;
+  render();
+}
+
+function resetGame() {
+  state.game = createInitialState();
+  state.selected = null;
+  state.snapshots = [];
+  state.isThinking = false;
+  render();
+  maybeAIMove();
+}
+
+function wireEvents() {
+  boardEl.addEventListener('click', (event) => {
+    const node = event.target.closest('.adugo-node');
+    if (!node) return;
+    selectNode(Number(node.dataset.index));
+  });
+
+  boardEl.addEventListener('keydown', (event) => {
+    const node = event.target.closest('.adugo-node');
+    if (!node) return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      selectNode(Number(node.dataset.index));
+    }
+  });
+
+  modeEl.addEventListener('change', () => {
+    state.mode = modeEl.value;
+    resetGame();
+  });
+
+  sideEl.addEventListener('change', () => {
+    state.humanSide = sideEl.value;
+    resetGame();
+  });
+
+  diffEl.addEventListener('change', () => {
+    state.difficulty = diffEl.value;
+    render();
+  });
+
+  newGameEl.addEventListener('click', resetGame);
+  undoEl.addEventListener('click', undoMove);
+}
+
+function setupHelpTabs() {
+  const buttons = document.querySelectorAll('[data-tab-button]');
+  const panels = document.querySelectorAll('[data-tab-panel]');
+
+  buttons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const tab = btn.dataset.tabButton;
+      buttons.forEach((b) => b.setAttribute('aria-selected', String(b === btn)));
+      panels.forEach((panel) => {
+        panel.hidden = panel.dataset.tabPanel !== tab;
+      });
+    });
+  });
+}
+
+function init() {
+  buildBoard();
+  wireEvents();
+  setupHelpTabs();
+  render();
+}
+
+init();

--- a/games/adugo/index.html
+++ b/games/adugo/index.html
@@ -1,136 +1,142 @@
-<!doctype html><html lang=en dir=auto><head><meta charset=utf-8><meta http-equiv=X-UA-Compatible content="IE=edge"><meta name=viewport content="width=device-width,initial-scale=1,shrink-to-fit=no"><meta name=robots content="index, follow"><title>Adugo | lucia's notes</title>
-<meta name=keywords content><meta name=description content="Adugo: The Game of the Jaguar and Dogs
-Adugo, also known as &ldquo;Jaguar and Dogs,&rdquo; is a traditional game played by the Bororo people in Brazil. This game simulates a hunting scenario and shares similarities with other strategic games from Southeast Asia.
-Overview of the Game
-Adugo is played on a board where the black piece represents the jaguar, and the white pieces represent the dogs. The game is an asymmetrical strategy challenge, where each side has distinct goals and abilities.
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Adugo | lucia's notes</title>
+  <meta name="description" content="Play Adugo (Jaguar and Dogs) online: human vs human or human vs computer with selectable difficulty." />
+  <link rel="stylesheet" href="/assets/css/stylesheet.5ad9b1caa92e4cea83ebcd3088e97362f239b07d8144490aaf0bc1d6bd89cd17.css" />
+  <link rel="stylesheet" href="/assets/css/adugo.css" />
+</head>
+<body class="dark" id="top">
+  <header class="header">
+    <nav class="nav">
+      <div class="logo"><a href="/" title="lucia's notes">lucia's notes</a></div>
+      <ul class="menu">
+        <li><a href="/about/">about</a></li>
+        <li><a href="/posts/">notes</a></li>
+        <li><a href="/games/">games</a></li>
+      </ul>
+    </nav>
+  </header>
 
+  <main class="main">
+    <article class="post-single">
+      <header class="post-header">
+        <div class="breadcrumbs"><a href="/">Home</a> » <a href="/games/">games</a></div>
+        <h1 class="post-title">Adugo — Jaguar and Dogs</h1>
+        <div class="post-meta">Playable online • Human vs Human / Human vs Computer</div>
+      </header>
 
+      <div class="post-content">
+        <section class="adugo-shell" aria-label="Adugo game area">
+          <header class="adugo-header">
+            <div>
+              <h2>Adugo Arena</h2>
+              <p class="adugo-subtitle">Asymmetrical hunt game on a line-based graph board.</p>
+            </div>
+            <p class="adugo-subtitle">Jaguar starts first</p>
+          </header>
 
+          <p class="adugo-win-banner" data-win-banner hidden></p>
 
+          <div class="adugo-main">
+            <section class="adugo-board-wrap" aria-label="Board section">
+              <div class="adugo-board" data-adugo-board role="grid" aria-label="Adugo board"></div>
 
-    
-    
-    
-        
-    
+              <div class="adugo-tabs">
+                <ul class="adugo-tab-list" role="tablist" aria-label="Adugo information tabs">
+                  <li><button class="adugo-tab" role="tab" aria-selected="true" data-tab-button="rules">Rules</button></li>
+                  <li><button class="adugo-tab" role="tab" aria-selected="false" data-tab-button="play">How to play</button></li>
+                  <li><button class="adugo-tab" role="tab" aria-selected="false" data-tab-button="tips">Strategy tips</button></li>
+                </ul>
 
-"><meta name=author content="Lucia"><link rel=canonical href=https://ldomenichelli.github.io/games/adugo/><link crossorigin=anonymous href=/assets/css/stylesheet.5ad9b1caa92e4cea83ebcd3088e97362f239b07d8144490aaf0bc1d6bd89cd17.css integrity="sha256-WtmxyqkuTOqD680wiOlzYvI5sH2BREkKrwvB1r2JzRc=" rel="preload stylesheet" as=style><link rel=icon href=https://ldomenichelli.github.io/favicon.ico><link rel=icon type=image/png sizes=16x16 href=https://ldomenichelli.github.io/favicon-16x16.png><link rel=icon type=image/png sizes=32x32 href=https://ldomenichelli.github.io/favicon-32x32.png><link rel=apple-touch-icon href=https://ldomenichelli.github.io/apple-touch-icon.png><link rel=mask-icon href=https://ldomenichelli.github.io/safari-pinned-tab.svg><meta name=theme-color content="#2e2e33"><meta name=msapplication-TileColor content="#2e2e33"><link rel=alternate hreflang=en href=https://ldomenichelli.github.io/games/adugo/><noscript><style>#theme-toggle,.top-link{display:none}</style></noscript><link rel=stylesheet href=https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css integrity=sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X crossorigin=anonymous><script defer src=https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js integrity=sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4 crossorigin=anonymous></script><script defer src=https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js integrity=sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa crossorigin=anonymous onload='renderMathInElement(document.body,{delimiters:[{left:"$$",right:"$$",display:!0},{left:"$",right:"$",display:!1},{left:"\\(",right:"\\)",display:!1},{left:"\\[",right:"\\]",display:!0}]})'></script><style>@media screen and (min-width:769px){.post-content input[type=checkbox]:checked~label>img{transform:scale(1.6);cursor:zoom-out;position:relative;z-index:999}.post-content img.zoomCheck{transition:transform .15s ease;z-index:999;cursor:zoom-in}}</style><meta property="og:title" content="Adugo"><meta property="og:description" content="Adugo: The Game of the Jaguar and Dogs
-Adugo, also known as &ldquo;Jaguar and Dogs,&rdquo; is a traditional game played by the Bororo people in Brazil. This game simulates a hunting scenario and shares similarities with other strategic games from Southeast Asia.
-Overview of the Game
-Adugo is played on a board where the black piece represents the jaguar, and the white pieces represent the dogs. The game is an asymmetrical strategy challenge, where each side has distinct goals and abilities.
+                <section class="adugo-tab-panel" data-tab-panel="rules" role="tabpanel">
+                  <ul>
+                    <li>Board is a graph: pieces move only along connected lines.</li>
+                    <li>Jaguar moves one step, or captures by jumping over an adjacent dog to an empty connected landing node.</li>
+                    <li>Dogs cannot capture; they win by trapping the jaguar so it has no legal moves.</li>
+                    <li>Jaguar continues a capture chain in the same turn when additional captures are available.</li>
+                  </ul>
+                </section>
 
+                <section class="adugo-tab-panel" data-tab-panel="play" role="tabpanel" hidden>
+                  <ol>
+                    <li>Select one of your pieces (highlighted by turn).</li>
+                    <li>Legal destinations glow in blue (capture landings in red).</li>
+                    <li>In Human vs Computer mode, input is locked while the AI is thinking.</li>
+                  </ol>
+                </section>
 
+                <section class="adugo-tab-panel" data-tab-panel="tips" role="tabpanel" hidden>
+                  <p><strong>Jaguar:</strong> stay mobile, keep central lanes open, and chain captures when possible.</p>
+                  <p><strong>Dogs:</strong> build a net, avoid isolated dogs, and close diagonals around the jaguar.</p>
+                </section>
+              </div>
+            </section>
 
+            <aside class="adugo-side" aria-label="Game controls and status">
+              <section class="adugo-card">
+                <p class="adugo-label">Mode & setup</p>
+                <div class="adugo-grid2">
+                  <div class="adugo-field">
+                    <label for="adugo-mode">Mode</label>
+                    <select id="adugo-mode" class="adugo-select" data-mode>
+                      <option value="HUMAN_VS_HUMAN">Human vs Human</option>
+                      <option value="HUMAN_VS_COMPUTER">Human vs Computer</option>
+                    </select>
+                  </div>
+                  <div class="adugo-field">
+                    <label for="adugo-side">Play as</label>
+                    <select id="adugo-side" class="adugo-select" data-side>
+                      <option value="JAGUAR">Jaguar</option>
+                      <option value="DOGS">Dogs</option>
+                    </select>
+                  </div>
+                </div>
 
+                <div class="adugo-field" style="margin-top: .55rem;">
+                  <label for="adugo-difficulty">Difficulty</label>
+                  <select id="adugo-difficulty" class="adugo-select" data-difficulty>
+                    <option value="Easy">Easy</option>
+                    <option value="Medium" selected>Medium</option>
+                    <option value="Hard">Hard</option>
+                  </select>
+                </div>
+              </section>
 
-    
-    
-    
-        
-    
+              <section class="adugo-card">
+                <p class="adugo-label">Status</p>
+                <div class="adugo-stat"><span>Turn</span><strong data-turn>Jaguar</strong></div>
+                <div class="adugo-stat"><span>Dogs captured</span><strong data-captured>0</strong></div>
+                <p class="adugo-status" data-status>Jaguar to move.</p>
+                <p class="adugo-thinking" data-thinking hidden>Computer thinking…</p>
+                <p class="adugo-status" data-objective></p>
+              </section>
 
-"><meta property="og:type" content="article"><meta property="og:url" content="https://ldomenichelli.github.io/games/adugo/"><meta property="og:image" content="https://ldomenichelli.github.io/img/adugo.jpeg"><meta property="article:section" content="games"><meta property="og:site_name" content="lucia's notes"><meta name=twitter:card content="summary_large_image"><meta name=twitter:image content="https://ldomenichelli.github.io/img/adugo.jpeg"><meta name=twitter:title content="Adugo"><meta name=twitter:description content="Adugo: The Game of the Jaguar and Dogs
-Adugo, also known as &ldquo;Jaguar and Dogs,&rdquo; is a traditional game played by the Bororo people in Brazil. This game simulates a hunting scenario and shares similarities with other strategic games from Southeast Asia.
-Overview of the Game
-Adugo is played on a board where the black piece represents the jaguar, and the white pieces represent the dogs. The game is an asymmetrical strategy challenge, where each side has distinct goals and abilities.
+              <section class="adugo-card">
+                <p class="adugo-label">Move history</p>
+                <ol class="adugo-history" data-history></ol>
+              </section>
 
+              <section class="adugo-card">
+                <p class="adugo-label">Controls</p>
+                <div class="adugo-grid2">
+                  <button class="adugo-button" data-new-game>New game</button>
+                  <button class="adugo-button" data-undo>Undo</button>
+                </div>
+              </section>
+            </aside>
+          </div>
+        </section>
+      </div>
+    </article>
+  </main>
 
+  <footer class="footer" style="padding-top:18px;padding-bottom:18px">
+    <span>© 2026 <a href="/">lucia's notes</a></span>
+  </footer>
 
-
-
-    
-    
-    
-        
-    
-
-"><script type=application/ld+json>{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"","item":"https://ldomenichelli.github.io/games/"},{"@type":"ListItem","position":2,"name":"Adugo","item":"https://ldomenichelli.github.io/games/adugo/"}]}</script><script type=application/ld+json>{"@context":"https://schema.org","@type":"BlogPosting","headline":"Adugo","name":"Adugo","description":"Adugo: The Game of the Jaguar and Dogs Adugo, also known as \u0026ldquo;Jaguar and Dogs,\u0026rdquo; is a traditional game played by the Bororo people in Brazil. This game simulates a hunting scenario and shares similarities with other strategic games from Southeast Asia.\nOverview of the Game Adugo is played on a board where the black piece represents the jaguar, and the white pieces represent the dogs. The game is an asymmetrical strategy challenge, where each side has distinct goals and abilities. ","keywords":[],"articleBody":"Adugo: The Game of the Jaguar and Dogs Adugo, also known as “Jaguar and Dogs,” is a traditional game played by the Bororo people in Brazil. This game simulates a hunting scenario and shares similarities with other strategic games from Southeast Asia.\nOverview of the Game Adugo is played on a board where the black piece represents the jaguar, and the white pieces represent the dogs. The game is an asymmetrical strategy challenge, where each side has distinct goals and abilities. How to Play Setup: The board consists of intersecting lines forming a grid. The jaguar starts on one side of the board, while the dogs are positioned on the opposite side. First Move: The jaguar always moves first. Movement Rules: Jaguar: Can move one intersection at a time, along orthogonal or diagonal lines. Dogs: Each dog moves one intersection at a time, along the same lines. Capturing: The jaguar can capture dogs by jumping over them, akin to the rules in checkers. A capture is only possible if the spot directly behind the dog is vacant. Winning the Game Jaguar’s Goal: Capture all the dogs. Dogs’ Goal: Surround and trap the jaguar so it cannot move. CN6gs2sN 329681219498\n","wordCount":"199","inLanguage":"en","image":"https://ldomenichelli.github.io/img/adugo.jpeg","datePublished":"0001-01-01T00:00:00Z","dateModified":"0001-01-01T00:00:00Z","author":{"@type":"Person","name":"Lucia"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://ldomenichelli.github.io/games/adugo/"},"publisher":{"@type":"Organization","name":"lucia's notes","logo":{"@type":"ImageObject","url":"https://ldomenichelli.github.io/favicon.ico"}}}</script></head><body class=dark id=top><header class=header><nav class=nav><div class=logo><a href=https://ldomenichelli.github.io/ accesskey=h title="lucia's notes (Alt + H)">lucia's notes</a><div class=logo-switches><ul class=lang-switch><li>|</li></ul></div></div><button id=menu-trigger aria-haspopup=menu aria-label="Menu Button"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentcolor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-menu"><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="18" x2="21" y2="18"/></svg></button><ul class="menu hidden"><li><a href=https://ldomenichelli.github.io/about/ title=about><span>about</span></a></li><li><a href=https://ldomenichelli.github.io/posts/ title=notes><span>notes</span></a></li><li><a href=https://ldomenichelli.github.io/random/ title=hobbies><span>hobbies</span></a></li></ul></nav></header><main class=main><article class=post-single><header class=post-header><div class=breadcrumbs><a href=https://ldomenichelli.github.io/>Home</a>&nbsp;»&nbsp;<a href=https://ldomenichelli.github.io/games/></a></div><h1 class=post-title>Adugo</h1><div class=post-meta>Lucia</div></header><div class="toc side left"><details open><summary accesskey=c title="(Alt + C)"><span class=details>Table of Contents</span></summary><div class=inner><nav id=TableOfContents><ul><li><a href=#overview-of-the-game>Overview of the Game</a><ul><li><a href=#how-to-play>How to Play</a></li><li><a href=#winning-the-game>Winning the Game</a></li></ul></li></ul></nav></div></details></div><div class=post-content><h1 id=adugo-the-game-of-the-jaguar-and-dogs>Adugo: The Game of the Jaguar and Dogs<a hidden class=anchor aria-hidden=true href=#adugo-the-game-of-the-jaguar-and-dogs>#</a></h1><p>Adugo, also known as &ldquo;Jaguar and Dogs,&rdquo; is a traditional game played by the <a href=https://pib.socioambiental.org/en/Povo:Bororo>Bororo</a> people in Brazil. This game simulates a hunting scenario and shares similarities with other strategic games from Southeast Asia.</p><h2 id=overview-of-the-game>Overview of the Game<a hidden class=anchor aria-hidden=true href=#overview-of-the-game>#</a></h2><p>Adugo is played on a board where the black piece represents the <strong>jaguar</strong>, and the white pieces represent the <strong>dogs</strong>. The game is an asymmetrical strategy challenge, where each side has distinct goals and abilities.
-<input type=checkbox id=zoomCheck-06b52 hidden>
-<label for=zoomCheck-06b52><img class=zoomCheck loading=lazy decoding=async src=img/plancia.png alt=plancia></label></p><h3 id=how-to-play>How to Play<a hidden class=anchor aria-hidden=true href=#how-to-play>#</a></h3><ol><li><strong>Setup</strong>: The board consists of intersecting lines forming a grid. The jaguar starts on one side of the board, while the dogs are positioned on the opposite side.</li><li><strong>First Move</strong>: The jaguar always moves first.</li><li><strong>Movement Rules</strong>:<ul><li><strong>Jaguar</strong>: Can move one intersection at a time, along orthogonal or diagonal lines.</li><li><strong>Dogs</strong>: Each dog moves one intersection at a time, along the same lines.</li></ul></li><li><strong>Capturing</strong>:<ul><li>The jaguar can capture dogs by jumping over them, akin to the rules in checkers.</li><li>A capture is only possible if the spot directly behind the dog is vacant.</li></ul></li></ol><h3 id=winning-the-game>Winning the Game<a hidden class=anchor aria-hidden=true href=#winning-the-game>#</a></h3><ul><li><strong>Jaguar&rsquo;s Goal</strong>: Capture all the dogs.</li><li><strong>Dogs&rsquo; Goal</strong>: Surround and trap the jaguar so it cannot move.</li></ul><div id=adugo-container></div><script>document.addEventListener("DOMContentLoaded",()=>{const e=document.getElementById("adugo-container");e.innerHTML=`
-            <style>
-                .board {
-                    display: grid;
-                    grid-template-columns: repeat(5, 80px);
-                    gap: 5px;
-                    margin: 20px auto;
-                    width: 400px;
-                }
-                .cell {
-                    width: 80px;
-                    height: 80px;
-                    background: #fff;
-                    border: 1px solid #000;
-                    position: relative;
-                }
-                .jaguar {
-                    width: 60px;
-                    height: 60px;
-                    background: gold;
-                    border-radius: 50%;
-                    margin: auto;
-                    position: absolute;
-                    top: 10px;
-                    left: 10px;
-                }
-                .dog {
-                    width: 60px;
-                    height: 60px;
-                    background: gray;
-                    border-radius: 50%;
-                    margin: auto;
-                    position: absolute;
-                    top: 10px;
-                    left: 10px;
-                }
-            </style>
-            <div class="board"></div>
-            <script>
-                const board = document.querySelector('.board');
-                const rows = 5;
-                const cols = 5;
-
-                const jaguar = { position: 12 }; // Starting position
-                const dogs = [0, 1, 2, 3, 4]; // Initial positions
-
-                function createBoard() {
-                    for (let i = 0; i < rows * cols; i++) {
-                        const cell = document.createElement('div');
-                        cell.classList.add('cell');
-                        cell.dataset.index = i;
-                        board.appendChild(cell);
-                    }
-                    placePieces();
-                }
-
-                function placePieces() {
-                    // Place Jaguar
-                    const jaguarCell = document.querySelector(
-                        \`.cell[data-index="${jaguar.position}"]\`
-                    );
-                    const jaguarDiv = document.createElement('div');
-                    jaguarDiv.classList.add('jaguar');
-                    jaguarCell.appendChild(jaguarDiv);
-
-                    // Place Dogs
-                    dogs.forEach((pos) => {
-                        const dogCell = document.querySelector(
-                            \`.cell[data-index="${pos}"]\`
-                        );
-                        const dogDiv = document.createElement('div');
-                        dogDiv.classList.add('dog');
-                        dogCell.appendChild(dogDiv);
-                    });
-                }
-
-                createBoard();
-            </script>
-        `})</script><dl><dt>CN6gs2sN</dt><dd><p>329681219498</p></dd></dl></div><footer class=post-footer><ul class=post-tags></ul></footer></article></main><footer class=footer style=padding-top:18px;padding-bottom:18px><div class=social-icons style=padding-bottom:0><a style=border-bottom:none href=https://x.com/workerplacemint rel=me title=Twitter><svg viewBox="0 0 24 24" fill="none" stroke="currentcolor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M23 3a10.9 10.9.0 01-3.14 1.53 4.48 4.48.0 00-7.86 3v1A10.66 10.66.0 013 4s-4 9 5 13a11.64 11.64.0 01-7 2c9 5 20 0 20-11.5a4.5 4.5.0 00-.08-.83A7.72 7.72.0 0023 3z"/></svg>
-</a><a style=border-bottom:none href=https://github.com/ldomenichelli rel=me title=Github><svg viewBox="0 0 24 24" fill="none" stroke="currentcolor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37.0 00-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44.0 0020 4.77 5.07 5.07.0 0019.91 1S18.73.65 16 2.48a13.38 13.38.0 00-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07.0 005 4.77 5.44 5.44.0 003.5 8.55c0 5.42 3.3 6.61 6.44 7A3.37 3.37.0 009 18.13V22"/></svg>
-</a><a style=border-bottom:none href=mailto:ldomenichelli2@gmail.com rel=me title=Email><svg viewBox="0 0 24 21" fill="none" stroke="currentcolor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1.0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1.0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg></a></div><span>&copy; 2025 <a href=https://ldomenichelli.github.io/>lucia's notes</a></span>
-<span>•
-Powered by
-<a href=https://gohugo.io/>Hugo</a> &
-        <a href=https://github.com/adityatelange/hugo-PaperMod/>PaperMod</a>
-</span><span>•
-<a href=/privacy>Privacy Policy</a></span></footer><a href=#top aria-label="go to top" title="Go to Top (Alt + G)" class=top-link id=top-link accesskey=g><svg viewBox="0 0 12 6" fill="currentcolor"><path d="M12 6H0l6-6z"/></svg>
-</a><script>let b=document.querySelector("#menu-trigger"),m=document.querySelector(".menu");b.addEventListener("click",function(){m.classList.toggle("hidden")}),document.body.addEventListener("click",function(e){b.contains(e.target)||m.classList.add("hidden")})</script><script>let menu=document.getElementById("menu");menu&&(menu.scrollLeft=localStorage.getItem("menu-scroll-position"),menu.onscroll=function(){localStorage.setItem("menu-scroll-position",menu.scrollLeft)}),document.querySelectorAll('a[href^="#"]').forEach(e=>{e.addEventListener("click",function(e){e.preventDefault();var t=this.getAttribute("href").substr(1);window.matchMedia("(prefers-reduced-motion: reduce)").matches?document.querySelector(`[id='${decodeURIComponent(t)}']`).scrollIntoView():document.querySelector(`[id='${decodeURIComponent(t)}']`).scrollIntoView({behavior:"smooth"}),t==="top"?history.replaceState(null,null," "):history.pushState(null,null,`#${t}`)})})</script><script>var mybutton=document.getElementById("top-link");window.onscroll=function(){document.body.scrollTop>800||document.documentElement.scrollTop>800?(mybutton.style.visibility="visible",mybutton.style.opacity="1"):(mybutton.style.visibility="hidden",mybutton.style.opacity="0")}</script><script>document.querySelectorAll("pre > code").forEach(e=>{const n=e.parentNode.parentNode,t=document.createElement("button");t.classList.add("copy-code"),t.innerHTML="copy";function s(){t.innerHTML="copied!",setTimeout(()=>{t.innerHTML="copy"},2e3)}t.addEventListener("click",t=>{if("clipboard"in navigator){navigator.clipboard.writeText(e.textContent),s();return}const n=document.createRange();n.selectNodeContents(e);const o=window.getSelection();o.removeAllRanges(),o.addRange(n);try{document.execCommand("copy"),s()}catch{}o.removeRange(n)}),n.classList.contains("highlight")?n.appendChild(t):n.parentNode.firstChild==n||(e.parentNode.parentNode.parentNode.parentNode.parentNode.nodeName=="TABLE"?e.parentNode.parentNode.parentNode.parentNode.parentNode.appendChild(t):e.parentNode.appendChild(t))})</script></body></html>
+  <script type="module" src="/assets/js/adugo-page.js"></script>
+</body>
+</html>

--- a/tests/adugo-ai.test.mjs
+++ b/tests/adugo-ai.test.mjs
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { SIDES, getLegalMoves, isMoveLegal } from '../assets/js/adugo-engine.js';
+import { pickAIMove } from '../assets/js/adugo-ai.js';
+
+function state(overrides = {}) {
+  return {
+    jaguar: 12,
+    dogs: [6, 7, 11, 13, 17],
+    capturedDogs: 0,
+    turn: SIDES.JAGUAR,
+    winner: null,
+    moveNumber: 1,
+    chainCaptureFrom: null,
+    history: [],
+    ...overrides
+  };
+}
+
+test('AI always picks legal jaguar move', () => {
+  const s = state();
+  const move = pickAIMove(s, SIDES.JAGUAR, 'Hard');
+  assert.ok(move);
+  assert.ok(isMoveLegal(s, move));
+});
+
+test('AI always picks legal dogs move', () => {
+  const s = state({ turn: SIDES.DOGS });
+  const move = pickAIMove(s, SIDES.DOGS, 'Medium');
+  assert.ok(move);
+  assert.ok(isMoveLegal(s, move));
+});
+
+test('AI handles terminal or no-move positions', () => {
+  const terminal = state({ winner: SIDES.DOGS });
+  assert.equal(pickAIMove(terminal, SIDES.JAGUAR, 'Easy'), null);
+
+  const noMoves = state({
+    jaguar: 12,
+    dogs: [6, 7, 8, 11, 13, 16, 17, 18, 0, 2, 4, 10, 14, 20, 22, 24],
+    turn: SIDES.JAGUAR
+  });
+  assert.equal(getLegalMoves(noMoves).length, 0);
+  assert.equal(pickAIMove(noMoves, SIDES.JAGUAR, 'Medium'), null);
+});

--- a/tests/adugo-engine.test.mjs
+++ b/tests/adugo-engine.test.mjs
@@ -1,0 +1,113 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  SIDES,
+  GAME_CONFIG,
+  ADJACENCY,
+  createInitialState,
+  getLegalMoves,
+  getLegalJaguarCaptures,
+  applyMove,
+  isMoveLegal,
+  detectWinner
+} from '../assets/js/adugo-engine.js';
+
+function makeState(overrides = {}) {
+  return {
+    jaguar: 12,
+    dogs: [6, 7, 11, 13, 17],
+    capturedDogs: 0,
+    turn: SIDES.JAGUAR,
+    winner: null,
+    moveNumber: 1,
+    chainCaptureFrom: null,
+    history: [],
+    ...overrides
+  };
+}
+
+test('graph adjacency is symmetric and non-empty', () => {
+  for (const [node, neighbors] of ADJACENCY.entries()) {
+    assert.ok(neighbors.length > 0, `node ${node} should have neighbors`);
+    for (const n of neighbors) {
+      assert.ok(ADJACENCY.get(n).includes(node), `adjacency should be symmetric: ${node}<->${n}`);
+    }
+  }
+});
+
+test('dogs have only step moves and cannot capture', () => {
+  const state = makeState({
+    turn: SIDES.DOGS,
+    jaguar: 12,
+    dogs: [6, 7, 8]
+  });
+  const moves = getLegalMoves(state, SIDES.DOGS);
+  assert.ok(moves.length > 0);
+  assert.ok(moves.every((m) => m.type === 'move'));
+});
+
+test('jaguar capture requires valid empty landing node', () => {
+  const captureState = makeState({
+    jaguar: 12,
+    dogs: [7]
+  });
+  const captures = getLegalJaguarCaptures(captureState);
+  assert.ok(captures.some((m) => m.from === 12 && m.over === 7 && m.to === 2));
+
+  const blockedLandingState = makeState({
+    jaguar: 12,
+    dogs: [7, 2]
+  });
+  const blocked = getLegalJaguarCaptures(blockedLandingState);
+  assert.ok(!blocked.some((m) => m.over === 7 && m.to === 2));
+});
+
+test('multi-jump capture chain is generated and applied', () => {
+  let state = makeState({
+    jaguar: 12,
+    dogs: [7, 3],
+    turn: SIDES.JAGUAR
+  });
+
+  const first = getLegalJaguarCaptures(state).find((m) => m.from === 12 && m.to === 2);
+  assert.ok(first);
+
+  state = applyMove(state, first);
+  assert.equal(state.turn, SIDES.JAGUAR);
+  assert.equal(state.chainCaptureFrom, 2);
+  assert.equal(state.capturedDogs, 1);
+
+  const secondOptions = getLegalMoves(state);
+  const second = secondOptions.find((m) => m.type === 'capture');
+  assert.ok(second);
+
+  state = applyMove(state, second);
+  assert.equal(state.capturedDogs, 2);
+  assert.equal(state.chainCaptureFrom, null);
+  assert.equal(state.turn, SIDES.DOGS);
+});
+
+test('trap detection awards dogs win when jaguar has no legal move', () => {
+  const trapped = makeState({
+    jaguar: 12,
+    dogs: [6, 7, 8, 11, 13, 16, 17, 18, 0, 2, 4, 10, 14, 20, 22, 24],
+    turn: SIDES.JAGUAR
+  });
+  assert.equal(getLegalMoves(trapped, SIDES.JAGUAR).length, 0);
+  assert.equal(detectWinner(trapped), SIDES.DOGS);
+});
+
+test('win detection uses configured jaguar capture threshold', () => {
+  const almost = makeState({ capturedDogs: GAME_CONFIG.jaguarCaptureTarget - 1 });
+  assert.equal(detectWinner(almost), null);
+
+  const win = makeState({ capturedDogs: GAME_CONFIG.jaguarCaptureTarget });
+  assert.equal(detectWinner(win), SIDES.JAGUAR);
+});
+
+test('applyMove rejects illegal move', () => {
+  const state = createInitialState();
+  const illegal = { from: state.jaguar, to: state.jaguar, type: 'move' };
+  assert.equal(isMoveLegal(state, illegal), false);
+  assert.throws(() => applyMove(state, illegal));
+});


### PR DESCRIPTION
### Motivation

- Provide a fully interactive, browser-playable implementation of the traditional Adugo (Jaguar and Dogs) game with support for Human vs Human and Human vs Computer modes.
- Ship a reusable game engine and AI so the page can run deterministic game logic and configurable computer opponents.

### Description

- Introduces a game engine in `assets/js/adugo-engine.js` that models the graph board, adjacency, legal moves, capture chains, state serialization, and win detection via `SIDES`, `GAME_CONFIG`, `ADJACENCY`, `getLegalMoves`, `applyMove`, and `detectWinner` APIs.
- Adds an AI module in `assets/js/adugo-ai.js` exposing `pickAIMove` and `thinkAndPickAIMove` that use an ordered minimax with alpha‑beta, transposition caching, an evaluation function, and configurable difficulties.
- Adds the interactive page controller in `assets/js/adugo-page.js` that renders the board, wires UI controls, handles input, snapshots/undo, and coordinates AI turns. The page mounts via a module script in `games/adugo/index.html` which was replaced with a polished playable UI.
- Supplies visual styles in `assets/css/adugo.css` for the board, nodes, pieces, panels and controls, and adds two test suites `tests/adugo-engine.test.mjs` and `tests/adugo-ai.test.mjs` that exercise adjacency, move generation, capture chains, winner detection, and AI move legality.

### Testing

- Added unit tests under `tests/` for the engine and AI components covering adjacency symmetry, dog/jaguar move rules, captures and multi-jump chains, trap/win detection, and that `pickAIMove` always returns legal moves. 
- Ran the test suite with `node --test` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bad609871483218874b416f9ccf1c1)