### PR TITLE
Improve AI, add undo/session handling, UI polish and tests

### DIFF
--- a/assets/css/adugo.css
+++ b/assets/css/adugo.css
@@ -1,81 +1,141 @@
 :root {
-  --adugo-bg: #0f1116;
-  --adugo-panel: #171a23;
-  --adugo-panel-alt: #1d2230;
-  --adugo-border: #2f374d;
-  --adugo-text: #e9edf7;
-  --adugo-muted: #b3bfd9;
-  --adugo-accent: #83a4ff;
-  --adugo-accent-soft: rgba(131, 164, 255, 0.18);
-  --adugo-danger: #ff7b7b;
+  --adugo-bg: #0e1118;
+  --adugo-panel: #171c28;
+  --adugo-panel-alt: #1c2331;
+  --adugo-panel-soft: #212b3e;
+  --adugo-border: #33405b;
+  --adugo-text: #e9edf8;
+  --adugo-muted: #b4c0d9;
+  --adugo-accent: #7fa5ff;
+  --adugo-accent-soft: rgba(127, 165, 255, 0.22);
   --adugo-jaguar: #e8b43f;
   --adugo-dog: #d7dde8;
 }
 
 .adugo-shell {
-  margin-top: 0.75rem;
+  margin-top: 0.5rem;
   border: 1px solid var(--adugo-border);
   border-radius: 18px;
-  background: linear-gradient(175deg, #121521 0%, #0f1116 100%);
+  background: linear-gradient(170deg, #111623 0%, #0d1018 100%);
   color: var(--adugo-text);
-  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.33);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
   overflow: hidden;
 }
 
 .adugo-header {
   display: flex;
-  align-items: baseline;
   justify-content: space-between;
-  gap: 1rem;
-  padding: 0.9rem 1.1rem;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding: 0.8rem 0.95rem;
   border-bottom: 1px solid var(--adugo-border);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0));
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
 }
 
 .adugo-header h2 {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: 1.02rem;
   letter-spacing: 0.02em;
 }
 
 .adugo-subtitle {
   margin: 0;
   color: var(--adugo-muted);
-  font-size: 0.9rem;
+  font-size: 0.85rem;
+}
+
+.adugo-role-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.6rem;
+  padding: 0.7rem 0.9rem 0;
+}
+
+.adugo-role {
+  border: 1px solid var(--adugo-border);
+  border-radius: 12px;
+  background: var(--adugo-panel);
+  padding: 0.55rem 0.65rem;
+  text-align: left;
+}
+
+.adugo-role-jaguar {
+  box-shadow: inset 0 0 0 1px rgba(232, 180, 63, 0.25);
+}
+
+.adugo-role-dogs {
+  box-shadow: inset 0 0 0 1px rgba(210, 220, 240, 0.15);
+}
+
+
+.adugo-shell[data-turn='JAGUAR'] .adugo-role-jaguar,
+.adugo-shell[data-turn='DOGS'] .adugo-role-dogs {
+  border-color: #6a8ff4;
+  box-shadow: 0 0 0 1px rgba(106, 143, 244, 0.4), inset 0 0 0 1px rgba(106, 143, 244, 0.2);
+}
+
+.adugo-role-title {
+  margin: 0;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #bfcbed;
+}
+
+.adugo-role-text {
+  margin: 0.3rem 0 0;
+  color: #d7def0;
+  font-size: 0.82rem;
+}
+
+.adugo-progress-wrap {
+  margin-top: 0.35rem;
+  height: 7px;
+  border-radius: 999px;
+  background: #121827;
+  border: 1px solid #3a4865;
+  overflow: hidden;
+}
+
+.adugo-progress {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, #f6d47e, #d7922a);
+  transition: width 180ms ease;
 }
 
 .adugo-win-banner {
-  margin: 0.75rem 1rem 0;
+  margin: 0.7rem 0.9rem 0;
   padding: 0.55rem 0.8rem;
   border-radius: 10px;
-  border: 1px solid rgba(232, 180, 63, 0.5);
-  background: rgba(232, 180, 63, 0.12);
+  border: 1px solid rgba(232, 180, 63, 0.52);
+  background: rgba(232, 180, 63, 0.14);
   color: #ffe8ae;
-  font-weight: 600;
+  font-weight: 650;
 }
 
 .adugo-main {
   display: grid;
-  grid-template-columns: 1.5fr minmax(260px, 340px);
-  gap: 0.9rem;
-  padding: 0.9rem;
+  grid-template-columns: minmax(0, 1.7fr) minmax(270px, 320px);
+  gap: 0.7rem;
+  padding: 0.75rem 0.9rem 0.9rem;
 }
 
 .adugo-board-wrap {
   background: var(--adugo-panel);
   border: 1px solid var(--adugo-border);
   border-radius: 16px;
-  padding: 0.9rem;
+  padding: 0.75rem;
 }
 
 .adugo-board {
   position: relative;
   aspect-ratio: 1 / 1;
-  width: min(100%, 690px);
+  width: min(100%, 760px);
   margin: 0 auto;
-  background: radial-gradient(circle at top left, #2d3244 0%, #1f2432 35%, #171a23 100%);
+  background: radial-gradient(circle at top left, #323b53 0%, #21283a 34%, #171c28 100%);
   border-radius: 14px;
-  border: 1px solid #3a4562;
+  border: 1px solid #45567b;
   overflow: hidden;
 }
 
@@ -89,22 +149,22 @@
   position: absolute;
   transform-origin: 0 0;
   height: 2px;
-  background: linear-gradient(90deg, #4f5873, #5f6a8a);
-  opacity: 0.7;
+  background: linear-gradient(90deg, #5b6988, #7384ad);
+  opacity: 0.75;
 }
 
 .adugo-node {
   position: absolute;
-  width: clamp(34px, 6.4vw, 54px);
-  height: clamp(34px, 6.4vw, 54px);
-  margin-left: calc(clamp(34px, 6.4vw, 54px) * -0.5);
-  margin-top: calc(clamp(34px, 6.4vw, 54px) * -0.5);
+  width: clamp(34px, 5.4vw, 56px);
+  height: clamp(34px, 5.4vw, 56px);
+  margin-left: calc(clamp(34px, 5.4vw, 56px) * -0.5);
+  margin-top: calc(clamp(34px, 5.4vw, 56px) * -0.5);
   border-radius: 999px;
-  border: 2px solid #8fa0cc33;
-  background: #151928;
+  border: 2px solid #98a9d533;
+  background: #151b2b;
   z-index: 2;
   cursor: pointer;
-  transition: transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease;
+  transition: transform 130ms ease, box-shadow 130ms ease, border-color 130ms ease;
 }
 
 .adugo-node:hover,
@@ -116,77 +176,83 @@
 }
 
 .adugo-node.is-selected {
-  border-color: #8ec5ff;
-  box-shadow: 0 0 0 4px rgba(142, 197, 255, 0.2);
+  border-color: #99c9ff;
+  box-shadow: 0 0 0 4px rgba(153, 201, 255, 0.2);
 }
 
 .adugo-node.is-legal::after {
   content: '';
   position: absolute;
-  inset: 8px;
+  inset: 9px;
   border-radius: 50%;
-  background: rgba(131, 164, 255, 0.5);
+  background: rgba(127, 165, 255, 0.54);
 }
 
 .adugo-node.is-chain::after {
-  background: rgba(255, 123, 123, 0.75);
+  background: rgba(255, 131, 131, 0.82);
 }
 
 .piece {
   position: absolute;
-  inset: 5px;
+  inset: 4px;
   border-radius: 50%;
   z-index: 3;
 }
 
 .piece.jaguar {
-  background: radial-gradient(circle at 30% 26%, #ffde8c 0%, #e8b43f 62%, #9e6f00 100%);
-  box-shadow: inset 0 -3px 8px rgba(63, 38, 0, 0.45);
+  background: radial-gradient(circle at 30% 26%, #ffde8c 0%, #e8b43f 60%, #9b6f00 100%);
+  box-shadow: inset 0 -4px 8px rgba(63, 38, 0, 0.42);
 }
 
 .piece.dog {
-  background: radial-gradient(circle at 30% 26%, #f6f8fd 0%, #d7dde8 60%, #8a95ad 100%);
-  box-shadow: inset 0 -2px 8px rgba(30, 40, 65, 0.35);
+  background: radial-gradient(circle at 30% 26%, #f6f8fd 0%, #d7dde8 58%, #8e9db8 100%);
+  box-shadow: inset 0 -2px 8px rgba(31, 42, 69, 0.35);
 }
 
 .adugo-side {
   display: grid;
-  gap: 0.7rem;
+  gap: 0.55rem;
+  align-content: start;
 }
 
 .adugo-card {
   background: var(--adugo-panel-alt);
   border: 1px solid var(--adugo-border);
   border-radius: 12px;
-  padding: 0.75rem;
+  padding: 0.68rem;
 }
 
 .adugo-grid2 {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 0.5rem;
+  gap: 0.45rem;
 }
 
 .adugo-field {
   display: grid;
-  gap: 0.35rem;
+  gap: 0.32rem;
   text-align: left;
+}
+
+.adugo-field-stack {
+  margin-top: 0.55rem;
 }
 
 .adugo-field label,
 .adugo-label {
-  font-size: 0.82rem;
+  font-size: 0.78rem;
   color: var(--adugo-muted);
+  margin: 0;
 }
 
 .adugo-select,
 .adugo-button {
   font: inherit;
   color: var(--adugo-text);
-  background: #111624;
-  border: 1px solid #34405d;
-  border-radius: 10px;
-  padding: 0.42rem 0.55rem;
+  background: #111728;
+  border: 1px solid #3a4970;
+  border-radius: 9px;
+  padding: 0.4rem 0.52rem;
 }
 
 .adugo-button {
@@ -210,9 +276,9 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 1px dashed #3b4663;
-  padding: 0.35rem 0;
-  font-size: 0.93rem;
+  border-bottom: 1px dashed #425174;
+  padding: 0.3rem 0;
+  font-size: 0.9rem;
 }
 
 .adugo-stat:last-child {
@@ -220,101 +286,120 @@
 }
 
 .adugo-status {
-  margin: 0.3rem 0 0;
-  color: #d5ddf2;
-  font-size: 0.9rem;
+  margin: 0.35rem 0 0;
+  color: #d7deef;
+  font-size: 0.86rem;
 }
 
 .adugo-thinking {
-  margin: 0.4rem 0 0;
-  font-size: 0.85rem;
-  color: #9eb4ff;
+  margin: 0.32rem 0 0;
+  font-size: 0.83rem;
+  color: #a8bcff;
 }
 
 .adugo-history {
   list-style: none;
   margin: 0;
   padding: 0;
-  max-height: 170px;
+  max-height: 220px;
   overflow: auto;
   display: grid;
-  gap: 0.25rem;
+  gap: 0.24rem;
 }
 
 .adugo-history-item {
-  font-size: 0.84rem;
+  font-size: 0.82rem;
   color: #d7ddf0;
-  background: #121826;
-  border: 1px solid #2f3850;
+  background: #121a2b;
+  border: 1px solid #344361;
   border-radius: 8px;
-  padding: 0.3rem 0.45rem;
+  padding: 0.26rem 0.42rem;
 }
 
 .adugo-empty-history {
   color: var(--adugo-muted);
-  font-size: 0.85rem;
+  font-size: 0.82rem;
 }
 
 .adugo-tabs {
-  margin-top: 0.7rem;
+  margin-top: 0.62rem;
   border-top: 1px solid var(--adugo-border);
 }
 
 .adugo-tab-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.45rem;
+  gap: 0.4rem;
   margin: 0;
-  padding: 0.75rem 0 0;
+  padding: 0.62rem 0 0;
   list-style: none;
 }
 
 .adugo-tab {
-  border: 1px solid #36425f;
-  background: #13182a;
+  border: 1px solid #3b4a6c;
+  background: #131a2d;
   color: var(--adugo-muted);
   border-radius: 999px;
-  padding: 0.33rem 0.7rem;
+  padding: 0.28rem 0.62rem;
   cursor: pointer;
-  font-size: 0.82rem;
+  font-size: 0.79rem;
 }
 
 .adugo-tab[aria-selected='true'] {
   color: var(--adugo-text);
-  border-color: #6385e7;
-  background: #1a2340;
+  border-color: #6a8ff4;
+  background: #1b2544;
 }
 
 .adugo-tab-panel {
-  margin-top: 0.7rem;
-  background: var(--adugo-panel);
+  margin-top: 0.58rem;
+  background: var(--adugo-panel-soft);
   border: 1px solid var(--adugo-border);
-  border-radius: 12px;
-  padding: 0.75rem;
+  border-radius: 11px;
+  padding: 0.66rem;
   color: #d5deef;
-  font-size: 0.92rem;
+  font-size: 0.89rem;
 }
 
 .adugo-tab-panel p,
 .adugo-tab-panel ul,
 .adugo-tab-panel ol {
-  margin: 0.35rem 0;
+  margin: 0.3rem 0;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .adugo-node,
   .adugo-button,
-  .adugo-select {
+  .adugo-select,
+  .adugo-progress {
     transition: none;
   }
 }
 
-@media (max-width: 980px) {
+@media (max-width: 1024px) {
   .adugo-main {
     grid-template-columns: 1fr;
   }
 
   .adugo-board {
-    width: min(100%, 580px);
+    width: min(100%, 680px);
+  }
+
+  .adugo-history {
+    max-height: 180px;
+  }
+}
+
+@media (max-width: 780px) {
+  .adugo-role-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .adugo-grid2 {
+    grid-template-columns: 1fr;
+  }
+
+  .adugo-board {
+    width: min(100%, 600px);
   }
 }

--- a/assets/js/adugo-ai.js
+++ b/assets/js/adugo-ai.js
@@ -3,37 +3,20 @@ import {
   GAME_CONFIG,
   applyMove,
   getLegalMoves,
+  getLegalJaguarCaptures,
   serializeState,
   occupantAt,
   ADJACENCY
 } from './adugo-engine.js';
 
 const DIFFICULTY = {
-  Easy: { depth: 2, randomness: 0.45 },
-  Medium: { depth: 4, randomness: 0.15 },
-  Hard: { depth: 5, randomness: 0 }
+  Easy: { depth: 2, randomness: 0.4, maxNodes: 2200 },
+  Medium: { depth: 4, randomness: 0.12, maxNodes: 22000 },
+  Hard: { depth: 6, randomness: 0, maxNodes: 90000 }
 };
 
 function opposite(side) {
   return side === SIDES.JAGUAR ? SIDES.DOGS : SIDES.JAGUAR;
-}
-
-function jaguarMobility(state) {
-  return getLegalMoves({ ...state, turn: SIDES.JAGUAR, chainCaptureFrom: null }, SIDES.JAGUAR).length;
-}
-
-function dogNetPressure(state) {
-  const jaguarPos = state.jaguar;
-  let occupiedNeighbors = 0;
-  for (const n of ADJACENCY.get(jaguarPos)) {
-    if (occupantAt(state, n) === SIDES.DOGS) occupiedNeighbors += 1;
-  }
-  return occupiedNeighbors;
-}
-
-function immediateJaguarCaptures(state) {
-  return getLegalMoves({ ...state, turn: SIDES.JAGUAR, chainCaptureFrom: state.jaguar }, SIDES.JAGUAR)
-    .filter((m) => m.type === 'capture').length;
 }
 
 function centrality(index) {
@@ -42,55 +25,155 @@ function centrality(index) {
   return -Math.abs(2 - x) - Math.abs(2 - y);
 }
 
+function jaguarMobility(state) {
+  return getLegalMoves({ ...state, turn: SIDES.JAGUAR, chainCaptureFrom: null }, SIDES.JAGUAR).length;
+}
+
+function immediateJaguarCaptures(state, from = state.jaguar) {
+  return getLegalJaguarCaptures({ ...state, chainCaptureFrom: from }, from).length;
+}
+
+function dogNetPressure(state) {
+  let occupiedNeighbors = 0;
+  for (const n of ADJACENCY.get(state.jaguar)) {
+    if (occupantAt(state, n) === SIDES.DOGS) occupiedNeighbors += 1;
+  }
+  return occupiedNeighbors;
+}
+
+function dogCohesion(state) {
+  const dogs = state.dogs;
+  if (dogs.length <= 1) return 0;
+  let connectedPairs = 0;
+
+  for (let i = 0; i < dogs.length; i += 1) {
+    for (let j = i + 1; j < dogs.length; j += 1) {
+      if (ADJACENCY.get(dogs[i]).includes(dogs[j])) connectedPairs += 1;
+    }
+  }
+
+  return connectedPairs;
+}
+
+function exposedDogs(state) {
+  let exposed = 0;
+
+  for (const dog of state.dogs) {
+    for (const n of ADJACENCY.get(dog)) {
+      if (n !== state.jaguar) continue;
+
+      const jx = state.jaguar % GAME_CONFIG.size;
+      const jy = Math.floor(state.jaguar / GAME_CONFIG.size);
+      const dx = (dog % GAME_CONFIG.size) - jx;
+      const dy = Math.floor(dog / GAME_CONFIG.size) - jy;
+      const lx = (dog % GAME_CONFIG.size) + dx;
+      const ly = Math.floor(dog / GAME_CONFIG.size) + dy;
+      const landing = ly * GAME_CONFIG.size + lx;
+
+      if (
+        lx >= 0 && lx < GAME_CONFIG.size &&
+        ly >= 0 && ly < GAME_CONFIG.size &&
+        ADJACENCY.get(dog).includes(landing) &&
+        occupantAt(state, landing) == null
+      ) {
+        exposed += 1;
+      }
+    }
+  }
+
+  return exposed;
+}
+
+function chainPotential(state) {
+  const base = {
+    ...state,
+    turn: SIDES.JAGUAR,
+    chainCaptureFrom: null
+  };
+
+  const captures = getLegalJaguarCaptures(base, base.jaguar);
+  if (captures.length === 0) return 0;
+
+  let bestFollowUps = 0;
+  for (const capture of captures) {
+    const child = applyMove(base, capture);
+    const followUps = child.chainCaptureFrom != null
+      ? getLegalJaguarCaptures(child, child.chainCaptureFrom).length
+      : 0;
+    bestFollowUps = Math.max(bestFollowUps, followUps);
+  }
+
+  return captures.length + bestFollowUps;
+}
+
 function evaluate(state, side) {
   if (state.winner === SIDES.JAGUAR) return side === SIDES.JAGUAR ? 100000 : -100000;
   if (state.winner === SIDES.DOGS) return side === SIDES.DOGS ? 100000 : -100000;
 
   const mobility = jaguarMobility(state);
   const pressure = dogNetPressure(state);
-  const capturesSoon = immediateJaguarCaptures(state);
+  const capturesSoon = immediateJaguarCaptures(state, state.jaguar);
+  const chainScore = chainPotential(state);
+  const cohesion = dogCohesion(state);
+  const exposed = exposedDogs(state);
 
   const jaguarScore =
-    state.capturedDogs * 230 +
-    mobility * 25 +
-    capturesSoon * 80 +
-    centrality(state.jaguar) * 10 -
-    pressure * 35;
+    state.capturedDogs * 250 +
+    mobility * 26 +
+    capturesSoon * 85 +
+    chainScore * 46 +
+    centrality(state.jaguar) * 12 -
+    pressure * 38;
 
   const dogsScore =
-    pressure * 45 +
-    Math.max(0, 8 - mobility) * 32 -
-    state.capturedDogs * 210 -
-    capturesSoon * 95;
+    pressure * 50 +
+    cohesion * 7 +
+    Math.max(0, 9 - mobility) * 34 -
+    state.capturedDogs * 220 -
+    capturesSoon * 90 -
+    chainScore * 40 -
+    exposed * 18;
 
-  const evalFromJaguarPerspective = jaguarScore - dogsScore;
-  return side === SIDES.JAGUAR ? evalFromJaguarPerspective : -evalFromJaguarPerspective;
+  const fromJaguarPOV = jaguarScore - dogsScore;
+  return side === SIDES.JAGUAR ? fromJaguarPOV : -fromJaguarPOV;
 }
 
-function orderMoves(state, moves) {
+function orderMoves(moves) {
   return [...moves].sort((a, b) => {
-    const av = (a.type === 'capture' ? 6 : 0) + centrality(a.to);
-    const bv = (b.type === 'capture' ? 6 : 0) + centrality(b.to);
+    const av = (a.type === 'capture' ? 8 : 0) + centrality(a.to);
+    const bv = (b.type === 'capture' ? 8 : 0) + centrality(b.to);
     return bv - av;
   });
 }
 
-function minimax(state, depth, alpha, beta, maximizing, rootSide, table) {
-  const key = `${serializeState(state)}|${depth}|${maximizing}`;
-  if (table.has(key)) return table.get(key);
+function tableKey(state, maximizing) {
+  return `${serializeState(state)}|${maximizing ? 'max' : 'min'}`;
+}
+
+function minimax(state, depth, alpha, beta, maximizing, rootSide, table, context) {
+  context.nodes += 1;
+  if (context.nodes >= context.maxNodes) {
+    return { score: evaluate(state, rootSide), move: null };
+  }
+
+  const key = tableKey(state, maximizing);
+  const cached = table.get(key);
+  if (cached && cached.depth >= depth) {
+    return { score: cached.score, move: cached.move };
+  }
 
   if (depth === 0 || state.winner) {
     const score = evaluate(state, rootSide);
     const result = { score, move: null };
-    table.set(key, result);
+    table.set(key, { ...result, depth });
     return result;
   }
 
-  const moves = orderMoves(state, getLegalMoves(state, state.turn));
+  const moves = orderMoves(getLegalMoves(state, state.turn));
   if (moves.length === 0) {
     const score = evaluate(state, rootSide);
     const result = { score, move: null };
-    table.set(key, result);
+    table.set(key, { ...result, depth });
     return result;
   }
 
@@ -100,7 +183,7 @@ function minimax(state, depth, alpha, beta, maximizing, rootSide, table) {
     let bestScore = -Infinity;
     for (const move of moves) {
       const child = applyMove(state, move);
-      const { score } = minimax(child, depth - 1, alpha, beta, child.turn === rootSide, rootSide, table);
+      const { score } = minimax(child, depth - 1, alpha, beta, child.turn === rootSide, rootSide, table, context);
       if (score > bestScore) {
         bestScore = score;
         bestMove = move;
@@ -109,14 +192,14 @@ function minimax(state, depth, alpha, beta, maximizing, rootSide, table) {
       if (beta <= alpha) break;
     }
     const result = { score: bestScore, move: bestMove };
-    table.set(key, result);
+    table.set(key, { ...result, depth });
     return result;
   }
 
   let bestScore = Infinity;
   for (const move of moves) {
     const child = applyMove(state, move);
-    const { score } = minimax(child, depth - 1, alpha, beta, child.turn === rootSide, rootSide, table);
+    const { score } = minimax(child, depth - 1, alpha, beta, child.turn === rootSide, rootSide, table, context);
     if (score < bestScore) {
       bestScore = score;
       bestMove = move;
@@ -124,8 +207,9 @@ function minimax(state, depth, alpha, beta, maximizing, rootSide, table) {
     beta = Math.min(beta, bestScore);
     if (beta <= alpha) break;
   }
+
   const result = { score: bestScore, move: bestMove };
-  table.set(key, result);
+  table.set(key, { ...result, depth });
   return result;
 }
 
@@ -136,9 +220,16 @@ export function pickAIMove(state, side, difficulty = 'Medium') {
 
   const table = new Map();
   const maximizing = state.turn === side;
-  const { move } = minimax(state, settings.depth, -Infinity, Infinity, maximizing, side, table);
 
-  if (!move) return legal[0];
+  let bestMove = null;
+  for (let depth = 1; depth <= settings.depth; depth += 1) {
+    const context = { nodes: 0, maxNodes: settings.maxNodes };
+    const result = minimax(state, depth, -Infinity, Infinity, maximizing, side, table, context);
+    if (result.move) bestMove = result.move;
+    if (context.nodes >= settings.maxNodes) break;
+  }
+
+  if (!bestMove) return legal[0];
 
   if (settings.randomness > 0 && legal.length > 1) {
     const scored = legal.map((candidate) => {
@@ -146,16 +237,15 @@ export function pickAIMove(state, side, difficulty = 'Medium') {
       return { candidate, score: evaluate(child, side) };
     }).sort((a, b) => b.score - a.score);
 
-    const topBucketSize = Math.max(1, Math.ceil(scored.length * settings.randomness));
-    const bucket = scored.slice(0, topBucketSize);
-    const randomPick = bucket[Math.floor(Math.random() * bucket.length)].candidate;
-    return randomPick;
+    const bucketSize = Math.max(1, Math.ceil(scored.length * settings.randomness));
+    const bucket = scored.slice(0, bucketSize);
+    return bucket[Math.floor(Math.random() * bucket.length)].candidate;
   }
 
-  return move;
+  return bestMove;
 }
 
-export function thinkAndPickAIMove(state, side, difficulty = 'Medium', delayMs = 320) {
+export function thinkAndPickAIMove(state, side, difficulty = 'Medium', delayMs = 280) {
   return new Promise((resolve) => {
     setTimeout(() => {
       resolve(pickAIMove(state, side, difficulty));

--- a/assets/js/adugo-page.js
+++ b/assets/js/adugo-page.js
@@ -4,16 +4,11 @@ import {
   createInitialState,
   applyMove,
   getLegalMoves,
-  getLegalJaguarCaptures,
   indexToCoord,
   ADJACENCY
 } from './adugo-engine.js';
 import { thinkAndPickAIMove, opposite } from './adugo-ai.js';
-
-const MODE = {
-  HVH: 'HUMAN_VS_HUMAN',
-  HVC: 'HUMAN_VS_COMPUTER'
-};
+import { MODE, computeUndoResult } from './adugo-session.js';
 
 const state = {
   game: createInitialState(),
@@ -26,8 +21,12 @@ const state = {
 };
 
 const boardEl = document.querySelector('[data-adugo-board]');
+const shellEl = document.querySelector('.adugo-shell');
 const turnEl = document.querySelector('[data-turn]');
 const capturedEl = document.querySelector('[data-captured]');
+const remainingEl = document.querySelector('[data-remaining]');
+const captureProgressEl = document.querySelector('[data-capture-progress]');
+const captureRemainingEl = document.querySelector('[data-capture-remaining]');
 const objectiveEl = document.querySelector('[data-objective]');
 const statusEl = document.querySelector('[data-status]');
 const thinkingEl = document.querySelector('[data-thinking]');
@@ -46,17 +45,12 @@ function isHumanTurn() {
 }
 
 function canUndoPair() {
-  if (state.snapshots.length === 0) return false;
-  return true;
+  return state.snapshots.length > 0;
 }
 
 function pushSnapshot() {
   state.snapshots.push(structuredClone(state.game));
   if (state.snapshots.length > 200) state.snapshots.shift();
-}
-
-function popSnapshot() {
-  return state.snapshots.pop() ?? null;
 }
 
 function prettySide(side) {
@@ -123,11 +117,13 @@ function annotateHistory() {
     return;
   }
 
-  const items = state.game.history.slice(-200).map((h, idx) => {
+  const recentHistory = state.game.history.slice(-220);
+  const items = recentHistory.map((h, idx) => {
     const li = document.createElement('li');
     li.className = 'adugo-history-item';
     const capture = h.move.type === 'capture' ? ' ×' : '';
-    li.textContent = `${idx + 1}. ${prettySide(h.actorSide)} ${h.move.from + 1}→${h.move.to + 1}${capture}`;
+    const moveNo = state.game.history.length - recentHistory.length + idx + 1;
+    li.textContent = `${moveNo}. ${prettySide(h.actorSide)} ${h.move.from + 1}→${h.move.to + 1}${capture}`;
     return li;
   });
 
@@ -136,8 +132,7 @@ function annotateHistory() {
 }
 
 function currentObjectiveText() {
-  const needed = Math.max(0, GAME_CONFIG.jaguarCaptureTarget - state.game.capturedDogs);
-  return `Jaguar wins by capturing ${GAME_CONFIG.jaguarCaptureTarget} dogs. Remaining: ${needed}. Dogs win by trapping the jaguar.`;
+  return `Jaguar objective: capture ${GAME_CONFIG.jaguarCaptureTarget} total dogs. Dogs objective: trap the jaguar (0 legal moves).`;
 }
 
 function highlightLegalTargets() {
@@ -175,9 +170,17 @@ function highlightLegalTargets() {
 }
 
 function updateStatusPanel() {
+  const remaining = Math.max(0, GAME_CONFIG.jaguarCaptureTarget - state.game.capturedDogs);
+  const progressPct = (Math.min(state.game.capturedDogs, GAME_CONFIG.jaguarCaptureTarget) / GAME_CONFIG.jaguarCaptureTarget) * 100;
+
   turnEl.textContent = prettySide(state.game.turn);
   capturedEl.textContent = String(state.game.capturedDogs);
+  remainingEl.textContent = String(remaining);
+  captureRemainingEl.textContent = `Remaining captures: ${remaining}`;
+  captureProgressEl.style.width = `${progressPct}%`;
   objectiveEl.textContent = currentObjectiveText();
+
+  shellEl.dataset.turn = state.game.turn;
 
   if (state.game.winner) {
     statusEl.textContent = `${prettySide(state.game.winner)} win!`;
@@ -236,11 +239,7 @@ function selectNode(index) {
     return;
   }
 
-  if (occ === state.game.turn) {
-    state.selected = index;
-  } else {
-    state.selected = null;
-  }
+  state.selected = occ === state.game.turn ? index : null;
   render();
 }
 
@@ -279,19 +278,15 @@ function executeMove(move, opts = { triggerAI: true }) {
 function undoMove() {
   if (!canUndoPair()) return;
 
-  if (state.mode === MODE.HVC) {
-    const aiSide = opposite(state.humanSide);
-    let popped = popSnapshot();
-    if (!popped) return;
+  const result = computeUndoResult({
+    mode: state.mode,
+    humanSide: state.humanSide,
+    snapshots: state.snapshots,
+    currentGame: state.game
+  });
 
-    state.game = popped;
-    if (state.game.turn === aiSide && state.snapshots.length > 0) {
-      state.game = popSnapshot() ?? state.game;
-    }
-  } else {
-    state.game = popSnapshot() ?? state.game;
-  }
-
+  state.game = result.game;
+  state.snapshots = result.snapshots;
   state.selected = null;
   state.isThinking = false;
   render();

--- a/assets/js/adugo-session.js
+++ b/assets/js/adugo-session.js
@@ -1,0 +1,29 @@
+import { SIDES } from './adugo-engine.js';
+
+export const MODE = Object.freeze({
+  HVH: 'HUMAN_VS_HUMAN',
+  HVC: 'HUMAN_VS_COMPUTER'
+});
+
+export function computeUndoResult({ mode, humanSide, snapshots, currentGame }) {
+  if (!snapshots.length) {
+    return { game: currentGame, snapshots };
+  }
+
+  const nextSnapshots = [...snapshots];
+
+  if (mode === MODE.HVH) {
+    const game = nextSnapshots.pop() ?? currentGame;
+    return { game, snapshots: nextSnapshots };
+  }
+
+  // In HVC, try to revert to the last human-to-move state.
+  let game = nextSnapshots.pop() ?? currentGame;
+  const aiSide = humanSide === SIDES.JAGUAR ? SIDES.DOGS : SIDES.JAGUAR;
+
+  while (game.turn === aiSide && nextSnapshots.length > 0) {
+    game = nextSnapshots.pop() ?? game;
+  }
+
+  return { game, snapshots: nextSnapshots };
+}

--- a/games/adugo/index.html
+++ b/games/adugo/index.html
@@ -38,6 +38,24 @@
             <p class="adugo-subtitle">Jaguar starts first</p>
           </header>
 
+          <div class="adugo-role-strip" aria-label="Roles and objective summary">
+            <section class="adugo-role adugo-role-jaguar">
+              <p class="adugo-role-title">Jaguar</p>
+              <p class="adugo-role-text">Mobile hunter. Capture dogs by jumping.</p>
+            </section>
+            <section class="adugo-role adugo-role-dogs">
+              <p class="adugo-role-title">Dogs</p>
+              <p class="adugo-role-text">Pack defenders. Trap the jaguar.</p>
+            </section>
+            <section class="adugo-role adugo-role-objective">
+              <p class="adugo-role-title">Capture objective</p>
+              <div class="adugo-progress-wrap">
+                <div class="adugo-progress" data-capture-progress></div>
+              </div>
+              <p class="adugo-role-text" data-capture-remaining>Remaining captures: 14</p>
+            </section>
+          </div>
+
           <p class="adugo-win-banner" data-win-banner hidden></p>
 
           <div class="adugo-main">
@@ -57,20 +75,22 @@
                     <li>Jaguar moves one step, or captures by jumping over an adjacent dog to an empty connected landing node.</li>
                     <li>Dogs cannot capture; they win by trapping the jaguar so it has no legal moves.</li>
                     <li>Jaguar continues a capture chain in the same turn when additional captures are available.</li>
+                    <li>Current variant: jaguar wins by capturing all 14 dogs.</li>
                   </ul>
                 </section>
 
                 <section class="adugo-tab-panel" data-tab-panel="play" role="tabpanel" hidden>
                   <ol>
-                    <li>Select one of your pieces (highlighted by turn).</li>
+                    <li>Select one of your pieces (matching the current turn).</li>
                     <li>Legal destinations glow in blue (capture landings in red).</li>
                     <li>In Human vs Computer mode, input is locked while the AI is thinking.</li>
+                    <li>Undo in Human vs Computer mode reverts one full pair (human + AI) when possible.</li>
                   </ol>
                 </section>
 
                 <section class="adugo-tab-panel" data-tab-panel="tips" role="tabpanel" hidden>
-                  <p><strong>Jaguar:</strong> stay mobile, keep central lanes open, and chain captures when possible.</p>
-                  <p><strong>Dogs:</strong> build a net, avoid isolated dogs, and close diagonals around the jaguar.</p>
+                  <p><strong>Jaguar:</strong> maximize mobility, keep central lanes open, and chain captures when possible.</p>
+                  <p><strong>Dogs:</strong> create a compact net, deny escape lanes, and avoid isolated dogs that can be jumped.</p>
                 </section>
               </div>
             </section>
@@ -95,7 +115,7 @@
                   </div>
                 </div>
 
-                <div class="adugo-field" style="margin-top: .55rem;">
+                <div class="adugo-field adugo-field-stack">
                   <label for="adugo-difficulty">Difficulty</label>
                   <select id="adugo-difficulty" class="adugo-select" data-difficulty>
                     <option value="Easy">Easy</option>
@@ -109,8 +129,9 @@
                 <p class="adugo-label">Status</p>
                 <div class="adugo-stat"><span>Turn</span><strong data-turn>Jaguar</strong></div>
                 <div class="adugo-stat"><span>Dogs captured</span><strong data-captured>0</strong></div>
-                <p class="adugo-status" data-status>Jaguar to move.</p>
-                <p class="adugo-thinking" data-thinking hidden>Computer thinking…</p>
+                <div class="adugo-stat"><span>Need to win (Jaguar)</span><strong data-remaining>14</strong></div>
+                <p class="adugo-status" data-status aria-live="polite">Jaguar to move.</p>
+                <p class="adugo-thinking" data-thinking aria-live="polite" hidden>Computer thinking…</p>
                 <p class="adugo-status" data-objective></p>
               </section>
 

--- a/tests/adugo-ai.test.mjs
+++ b/tests/adugo-ai.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { SIDES, getLegalMoves, isMoveLegal } from '../assets/js/adugo-engine.js';
+import { SIDES, getLegalMoves, isMoveLegal, applyMove } from '../assets/js/adugo-engine.js';
 import { pickAIMove } from '../assets/js/adugo-ai.js';
 
 function state(overrides = {}) {
@@ -31,6 +31,21 @@ test('AI always picks legal dogs move', () => {
   assert.ok(isMoveLegal(s, move));
 });
 
+test('AI returns legal move for all difficulty levels and both sides', () => {
+  for (const difficulty of ['Easy', 'Medium', 'Hard']) {
+    const jaguarState = state({ turn: SIDES.JAGUAR });
+    const dogsState = state({ turn: SIDES.DOGS });
+
+    const jaguarMove = pickAIMove(jaguarState, SIDES.JAGUAR, difficulty);
+    const dogsMove = pickAIMove(dogsState, SIDES.DOGS, difficulty);
+
+    assert.ok(jaguarMove, `jaguar move missing (${difficulty})`);
+    assert.ok(dogsMove, `dogs move missing (${difficulty})`);
+    assert.ok(isMoveLegal(jaguarState, jaguarMove), `illegal jaguar move (${difficulty})`);
+    assert.ok(isMoveLegal(dogsState, dogsMove), `illegal dogs move (${difficulty})`);
+  }
+});
+
 test('AI handles terminal or no-move positions', () => {
   const terminal = state({ winner: SIDES.DOGS });
   assert.equal(pickAIMove(terminal, SIDES.JAGUAR, 'Easy'), null);
@@ -42,4 +57,17 @@ test('AI handles terminal or no-move positions', () => {
   });
   assert.equal(getLegalMoves(noMoves).length, 0);
   assert.equal(pickAIMove(noMoves, SIDES.JAGUAR, 'Medium'), null);
+});
+
+test('AI move can always be applied without throwing illegal move errors', () => {
+  let s = state();
+  for (let i = 0; i < 8; i += 1) {
+    const side = s.turn;
+    const move = pickAIMove(s, side, 'Medium');
+    assert.ok(move);
+    assert.doesNotThrow(() => {
+      s = applyMove(s, move);
+    });
+    if (s.winner) break;
+  }
 });

--- a/tests/adugo-engine.test.mjs
+++ b/tests/adugo-engine.test.mjs
@@ -35,6 +35,13 @@ test('graph adjacency is symmetric and non-empty', () => {
   }
 });
 
+
+test('configured variant starts with 14 dogs and jaguar target matches full capture', () => {
+  const initial = createInitialState();
+  assert.equal(initial.dogs.length, 14);
+  assert.equal(GAME_CONFIG.jaguarCaptureTarget, 14);
+});
+
 test('dogs have only step moves and cannot capture', () => {
   const state = makeState({
     turn: SIDES.DOGS,

--- a/tests/adugo-session.test.mjs
+++ b/tests/adugo-session.test.mjs
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { SIDES } from '../assets/js/adugo-engine.js';
+import { MODE, computeUndoResult } from '../assets/js/adugo-session.js';
+
+function makeGame(overrides = {}) {
+  return {
+    jaguar: 12,
+    dogs: [0, 1, 2],
+    capturedDogs: 0,
+    turn: SIDES.JAGUAR,
+    winner: null,
+    moveNumber: 1,
+    chainCaptureFrom: null,
+    history: [],
+    ...overrides
+  };
+}
+
+test('HVC undo rewinds to human turn when possible', () => {
+  const s0 = makeGame({ turn: SIDES.JAGUAR });
+  const s1 = makeGame({ turn: SIDES.DOGS });
+  const s2 = makeGame({ turn: SIDES.JAGUAR });
+
+  const result = computeUndoResult({
+    mode: MODE.HVC,
+    humanSide: SIDES.JAGUAR,
+    snapshots: [s0, s1, s2],
+    currentGame: makeGame({ turn: SIDES.DOGS })
+  });
+
+  assert.equal(result.game.turn, SIDES.JAGUAR);
+  assert.equal(result.snapshots.length, 2);
+});
+
+test('HVC undo degrades gracefully with limited snapshots', () => {
+  const only = makeGame({ turn: SIDES.DOGS });
+
+  const result = computeUndoResult({
+    mode: MODE.HVC,
+    humanSide: SIDES.JAGUAR,
+    snapshots: [only],
+    currentGame: makeGame({ turn: SIDES.JAGUAR })
+  });
+
+  assert.equal(result.game.turn, SIDES.DOGS);
+  assert.equal(result.snapshots.length, 0);
+});
+
+test('HVH undo pops exactly one snapshot', () => {
+  const s0 = makeGame({ moveNumber: 1 });
+  const s1 = makeGame({ moveNumber: 2 });
+
+  const result = computeUndoResult({
+    mode: MODE.HVH,
+    humanSide: SIDES.JAGUAR,
+    snapshots: [s0, s1],
+    currentGame: makeGame({ moveNumber: 3 })
+  });
+
+  assert.equal(result.game.moveNumber, 2);
+  assert.equal(result.snapshots.length, 1);
+});


### PR DESCRIPTION
### Motivation
- Improve the AI strength and stability by adding better heuristics, move ordering, iterative deepening and node caps to bound thinking time. 
- Make undo behavior predictable in Human-vs-Computer mode by factoring undo logic into a dedicated session helper. 
- Polish the UI to show role/objective info, capture progress, better responsiveness and visual tweaks. 

### Description
- Enhanced AI (`assets/js/adugo-ai.js`) with new evaluation features (`centrality`, `dogCohesion`, `exposedDogs`, `chainPotential`, improved immediate capture logic), updated weights, move ordering, iterative deepening, node-limit context (`maxNodes`) per difficulty, transposition cache keyed by state+side+depth metadata, and reduced think delay via `thinkAndPickAIMove`. 
- Added a session helper module (`assets/js/adugo-session.js`) exporting `MODE` and `computeUndoResult` to centralize undo semantics and properly revert to the last human-to-move state in HVC mode. 
- Updated page logic (`assets/js/adugo-page.js`) to use the new `MODE` and `computeUndoResult`, track snapshots, render capture progress and remaining captures, improve history numbering and sizing, simplify selection logic and wire UI state (`data-turn` on shell). 
- UI/UX and styling polish in `assets/css/adugo.css` including new role strip, progress bar, color and spacing adjustments, responsive breakpoints, and many sizing/visual refinements. 
- HTML changes (`games/adugo/index.html`) to add role/objective strip, progress UI, ARIA improvements and text clarifications. 
- Tests updated and added: `tests/adugo-ai.test.mjs` extended to verify moves across difficulties and apply moves safely, `tests/adugo-engine.test.mjs` added variant checks, and a new `tests/adugo-session.test.mjs` verifying undo behavior in HVC/HVH. 

### Testing
- Ran engine tests in `tests/adugo-engine.test.mjs` which verify adjacency symmetry and capture mechanics and the configured variant dog count; tests passed. 
- Ran AI tests in `tests/adugo-ai.test.mjs` which assert the AI returns legal moves across difficulties and sides and that moves can be applied; tests passed. 
- Ran new session tests in `tests/adugo-session.test.mjs` which validate undo semantics for HVC and HVH modes; tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbc3bd8eb0832182b280acabfe61b1)